### PR TITLE
Added code to allow for patching later in initialization process

### DIFF
--- a/Source/LatePatcher.cs
+++ b/Source/LatePatcher.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+
+using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    [StaticConstructorOnStartup]
+    public class LatePatcher
+    {
+        internal static readonly Harmony harmony = new Harmony("rimworld.multiplayer.late_compat");
+
+        static LatePatcher()
+        {
+            if (!MP.enabled) return;
+
+            var queue = MpCompat.content.assemblies.loadedAssemblies
+                .SelectMany(a => a.GetTypes())
+                .Join(LoadedModManager.RunningMods,
+                    type => type.TryGetAttribute<LateMpCompatForAttribute>()?.ModName,
+                    mod => mod.Name,
+                    (type, mod) => new { type, mod });
+
+            foreach (var action in queue)
+            {
+                try
+                {
+                    action.type.GetMethod("LateCompat", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public).Invoke(null, new[] { action.mod });
+                    //Activator.CreateInstance(action.type, action.mod);
+
+                    Log.Message($"MPCompat :: Initialized late compatibility for {action.mod.Name}");
+                }
+                catch (Exception e)
+                {
+                    Log.Error($"MPCompat :: Exception late loading {action.mod.Name}: {e.InnerException}");
+                }
+            }
+
+            MpCompat.harmony.PatchAll();
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Class)]
+    public class LateMpCompatForAttribute : Attribute
+    {
+        public string ModName { get; }
+
+        public LateMpCompatForAttribute(string modName)
+        {
+            this.ModName = modName;
+        }
+    }
+}

--- a/Source/MpCompat.cs
+++ b/Source/MpCompat.cs
@@ -10,10 +10,13 @@ namespace Multiplayer.Compat
     public class MpCompat : Mod
     {
         internal static readonly Harmony harmony = new Harmony("rimworld.multiplayer.compat");
+        internal static ModContentPack content;
 
         public MpCompat(ModContentPack content) : base(content)
         {
             if (!MP.enabled) return;
+
+            MpCompat.content = content;
 
             var queue = content.assemblies.loadedAssemblies
                 .SelectMany(a => a.GetTypes())


### PR DESCRIPTION
This code is used by 2 of my compatibility patches (that are still WIP), which is used to avoid graphical bugs related to classes initializing static fields that were supposed to be initialized later in the loading process.

Classes that are using `LateMpCompatForAttribute` should have a `public static` method with `ModContentPack` as the parameter.