### PR TITLE
Add Vanilla Events Expanded patch

### DIFF
--- a/Source/Mods/VanillaEventsExpanded.cs
+++ b/Source/Mods/VanillaEventsExpanded.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using Verse;
+
+namespace Multiplayer.Compat.Mods
+{
+    /// <summary>Vanilla Events Expanded by Oskar Potocki, Helixien, Kikohi</summary>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1938420742"/>
+    /// Contribution to Multiplayer Compatibility by Sokyran and Reshiram
+    [MpCompatFor("VanillaExpanded.VEE")]
+    class VEE
+    {
+        public VEE(ModContentPack mod)
+        {
+            // Methods with no System.Random calls, but calling methods that use it, or just using Verse.Rand
+            var methodsForRngSync = new[]
+            {
+                "VEE.DummySpaceBattle:CreateRandomExplosion",
+                "VEE.DummySpaceBattle:StartRandomFire",
+
+                "VEE.RegularEvents.EarthQuake:TryExecuteWorker",
+            };
+
+            var methodsForAll = new[]
+            {
+                "VEE.DummySpaceBattle:Tick",
+                "VEE.HeddifComp_MightJoin:CompPostTick",
+                "VEE.Shuttle:Tick",
+
+                // These 4 methods initialize System.Random, but don't use them in any way whatsoever. Should we patch them just in case?
+                //"VEE.PurpleEvents.GlobalWarming:ChangeBiomes",
+                //"VEE.PurpleEvents.GlobalWarming:ChangeTileTemp",
+                //"VEE.PurpleEvents.IceAge:ChangeBiomes",
+                //"VEE.PurpleEvents.IceAge:ChangeTileTemp",
+                "VEE.PurpleEvents.PsychicBloom:Init",
+
+                "VEE.RegularEvents.ApparelPod:TryExecuteWorker",
+                "VEE.RegularEvents.CaravanAnimalWI:GenerateGroup",
+                "VEE.RegularEvents.Drought:HarmPlant",
+                "VEE.RegularEvents.HuntingParty:TryExecuteWorker",
+                "VEE.RegularEvents.MeteoriteShower:TryExecuteWorker",
+                //"VEE.RegularEvents.SpaceBattle:GameConditionTick", // It includes several System.Random initializations, skipping for now
+                "VEE.RegularEvents.WeaponPod:TryExecuteWorker",
+            };
+
+            PatchingUtilities.PatchPushPopRand(methodsForRngSync);
+            PatchingUtilities.PatchSystemRand(methodsForAll);
+            // Only patch System.Random out, as those methods are called by other ones
+            MpCompat.harmony.Patch(AccessTools.Method("VEE.RegularEvents.EarthQuake:DamageInRadius"), transpiler: new HarmonyMethod(typeof(PatchingUtilities), nameof(PatchingUtilities.FixRNG)));
+        }
+    }
+}

--- a/Source/Mods/VanillaEventsExpanded.cs
+++ b/Source/Mods/VanillaEventsExpanded.cs
@@ -45,7 +45,8 @@ namespace Multiplayer.Compat.Mods
             PatchingUtilities.PatchPushPopRand(methodsForRngSync);
             PatchingUtilities.PatchSystemRand(methodsForAll);
             // Only patch System.Random out, as this methods is only called by other ones
-            MpCompat.harmony.Patch(AccessTools.Method("VEE.RegularEvents.EarthQuake:DamageInRadius"), transpiler: new HarmonyMethod(typeof(PatchingUtilities), nameof(PatchingUtilities.FixRNG)));
+            MpCompat.harmony.Patch(AccessTools.Method("VEE.RegularEvents.EarthQuake:DamageInRadius"),
+                transpiler: new HarmonyMethod(typeof(PatchingUtilities), nameof(PatchingUtilities.FixRNG)));
         }
     }
 }

--- a/Source/Mods/VanillaEventsExpanded.cs
+++ b/Source/Mods/VanillaEventsExpanded.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using HarmonyLib;
+﻿using HarmonyLib;
 using Verse;
 
 namespace Multiplayer.Compat.Mods
@@ -30,8 +25,8 @@ namespace Multiplayer.Compat.Mods
                 "VEE.DummySpaceBattle:Tick",
                 "VEE.HeddifComp_MightJoin:CompPostTick",
                 "VEE.Shuttle:Tick",
-
-                // These 4 methods initialize System.Random, but don't use them in any way whatsoever. Should we patch them just in case?
+                
+                // These 4 methods initialize System.Random, but don't use them in any way whatsoever.
                 //"VEE.PurpleEvents.GlobalWarming:ChangeBiomes",
                 //"VEE.PurpleEvents.GlobalWarming:ChangeTileTemp",
                 //"VEE.PurpleEvents.IceAge:ChangeBiomes",
@@ -43,13 +38,13 @@ namespace Multiplayer.Compat.Mods
                 "VEE.RegularEvents.Drought:HarmPlant",
                 "VEE.RegularEvents.HuntingParty:TryExecuteWorker",
                 "VEE.RegularEvents.MeteoriteShower:TryExecuteWorker",
-                //"VEE.RegularEvents.SpaceBattle:GameConditionTick", // It includes several System.Random initializations, skipping for now
+                //"VEE.RegularEvents.SpaceBattle:GameConditionTick", // This method was having issues with transpiling no matter what I did, skipping it until it can be fixed
                 "VEE.RegularEvents.WeaponPod:TryExecuteWorker",
             };
 
             PatchingUtilities.PatchPushPopRand(methodsForRngSync);
             PatchingUtilities.PatchSystemRand(methodsForAll);
-            // Only patch System.Random out, as those methods are called by other ones
+            // Only patch System.Random out, as this methods is only called by other ones
             MpCompat.harmony.Patch(AccessTools.Method("VEE.RegularEvents.EarthQuake:DamageInRadius"), transpiler: new HarmonyMethod(typeof(PatchingUtilities), nameof(PatchingUtilities.FixRNG)));
         }
     }

--- a/Source/PatchingUtilities.cs
+++ b/Source/PatchingUtilities.cs
@@ -79,67 +79,174 @@ namespace Multiplayer.Compat
         private static MethodInfo SystemNextMax = typeof(System.Random).GetMethod("Next", new Type[] { typeof(int) });
         private static MethodInfo SystemNextMinMax = typeof(System.Random).GetMethod("Next", new Type[] { typeof(int), typeof(int) });
         private static MethodInfo SystemNextDouble = typeof(System.Random).GetMethod("NextDouble");
+        private static ConstructorInfo SystemRandConstructor = typeof(System.Random).GetConstructor(Array.Empty<Type>());
         #endregion
 
         /// <summary>Method intended for patching <see cref="System.Random"/> calls out of instructions. Does not support <see cref="System.Random.NextBytes(byte[])"/>.</summary>
         /// <param name="instr">Instructions that need patching</param>
-        /// Currently, it only works with methods that are accessing System.Random calls for fields in classes.
+        /// Currently, it only works with methods that are accessing System.Random calls for fields in classes or initialize System.Random once in the method
         /// Contribution to Multiplayer Compatibility by Sokyran and Reshiram
         /// Please report issues with this method with .dll or .exe files (along with information on where to find the problematic code) or IL instructions related to the call
         internal static IEnumerable<CodeInstruction> FixRNG(IEnumerable<CodeInstruction> instr)
         {
+            OpCode? localRandomOpCode = null;
+            object localRandomOperand = null;
+
             for (int i = 0; i < instr.Count(); i++)
             {
                 var ci = instr.ElementAt(i);
-                if (ci.opcode == OpCodes.Callvirt && ci.operand is MethodInfo operand)
+
+                // Checking if random is defined inside of the method (there's high chance it won't work if random is defined more than once)
+                if (ci.opcode == OpCodes.Newobj && ci.operand is ConstructorInfo constructor && constructor == SystemRandConstructor)
                 {
-                    int PatchEarlierInstruction(int pos, OpCode codeFind, OpCode codeReplace, Type fieldType = null, object operandReplace = null)
+                    // Check if there's at least one more instruction (just in case)
+                    if (i + 1 < instr.Count())
+                        // Get equivalent Ldloc to our Stloc (assuming it's Stloc in the first place), so we can patch all apperances of it
+                        GetLdlocFromStloc(instr.ElementAt(i + 1), out localRandomOpCode, out localRandomOperand);
+                    // If we fou the random, then skip the next instructions (stloc)
+                    // We still need to include them in case any code branches jump to them, to prevent jumping to non-existant instruction
+                    // An alternative approach would be much more complicated to implement, as it would require patching any jumps to another instruction
+                    if (localRandomOpCode.HasValue)
                     {
-                        while (pos > 0)
-                        {
-                            pos--;
-
-                            var currentOperation = instr.ElementAt(pos);
-                            if (currentOperation.opcode == codeFind)
-                            {
-                                if (fieldType == null || (currentOperation.operand is FieldInfo info && info.FieldType == fieldType))
-                                {
-                                    currentOperation.opcode = codeReplace;
-                                    currentOperation.operand = operandReplace;
-                                    return pos;
-                                }
-                            }
-                        }
-
-                        return 0;
+                        i++;
+                        ci.opcode = OpCodes.Nop;
+                        ci.operand = null;
+                        yield return ci;
+                        ci = instr.ElementAt(i);
+                        ci.opcode = OpCodes.Nop;
+                        ci.operand = null;
                     }
+                    // If what we found isn't random, then just treat the instructions as normal
+                    yield return ci;
+                }
+                // Looking for calls to System.Random
+                else if (ci.opcode == OpCodes.Callvirt && ci.operand is MethodInfo operand)
+                {
+                    // Patching System.Next() as Verse.Rand.Range(0, int.MaxValue)
                     if (operand == SystemNext)
                     {
-                        var pos = PatchEarlierInstruction(i, OpCodes.Ldfld, OpCodes.Ldc_I4, typeof(System.Random), int.MaxValue);
-                        PatchEarlierInstruction(pos, OpCodes.Ldarg_0, OpCodes.Ldc_I4_0);
-                        yield return new CodeInstruction(opcode: OpCodes.Call, operand: RandRangeInt);
+                        if (localRandomOpCode.HasValue)
+                        {
+                            // Replace loading local random field with our first parameter
+                            PatchEarlierInstruction(instr, i, localRandomOpCode.Value, OpCodes.Ldc_I4_0, localRandomOperand);
+                            // Add a parameter for max value (since we don't have instructions to replace anymore)
+                            yield return new CodeInstruction(opcode: OpCodes.Ldc_I4, operand: int.MaxValue);
+                        }
+                        else
+                        {
+                            // Replace random loading from field into our rand parameters
+                            var pos = PatchEarlierInstruction(instr, i, OpCodes.Ldfld, OpCodes.Ldc_I4, typeof(System.Random), int.MaxValue);
+                            PatchEarlierInstruction(instr, pos, OpCodes.Ldarg_0, OpCodes.Ldc_I4_0);
+                        }
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = RandRangeInt;
                     }
+                    // Patching System.Next(max) as Verse.Rand.Range(0, max)
                     else if (operand == SystemNextMax)
                     {
-                        var pos = PatchEarlierInstruction(i, OpCodes.Ldfld, OpCodes.Ldc_I4_0, typeof(System.Random));
-                        PatchEarlierInstruction(pos, OpCodes.Ldarg_0, OpCodes.Nop);
-                        yield return new CodeInstruction(opcode: OpCodes.Call, operand: RandRangeInt);
+                        if (localRandomOpCode.HasValue)
+                        {
+                            // Replace loading local random field with our first parameter
+                            PatchEarlierInstruction(instr, i, localRandomOpCode.Value, OpCodes.Ldc_I4_0, localRandomOperand);
+                        }
+                        else
+                        {
+                            // Replace random loading from field into our first parameter and nop (as one of the parameters is provided)
+                            var pos = PatchEarlierInstruction(instr, i, OpCodes.Ldfld, OpCodes.Ldc_I4_0, typeof(System.Random));
+                            PatchEarlierInstruction(instr, pos, OpCodes.Ldarg_0, OpCodes.Nop);
+                        }
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = RandRangeInt;
                     }
+                    // Patching System.Next(min, max) as Verse.Rand.Range(min, max)
                     else if (operand == SystemNextMinMax)
                     {
-                        var pos = PatchEarlierInstruction(i, OpCodes.Ldfld, OpCodes.Nop, typeof(System.Random));
-                        PatchEarlierInstruction(pos, OpCodes.Ldarg_0, OpCodes.Nop);
-                        yield return new CodeInstruction(opcode: OpCodes.Call, operand: RandRangeInt);
+                        if (localRandomOpCode.HasValue)
+                        {
+                            // Replace loading local random field with nop (as we have both of our parameters)
+                            PatchEarlierInstruction(instr, i, localRandomOpCode.Value, OpCodes.Nop, localRandomOperand);
+                        }
+                        else
+                        {
+                            // Replace random loading from field into nop (as the parameters are already provided)
+                            var pos = PatchEarlierInstruction(instr, i, OpCodes.Ldfld, OpCodes.Nop, typeof(System.Random));
+                            PatchEarlierInstruction(instr, pos, OpCodes.Ldarg_0, OpCodes.Nop);
+                        }
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = RandRangeInt;
                     }
+                    // Patching System.NextDouble() as Verse.Rand.Range(0f, 1f)
                     else if (operand == SystemNextDouble)
                     {
-                        var pos = PatchEarlierInstruction(i, OpCodes.Ldfld, OpCodes.Ldc_R4, typeof(System.Random), 1f);
-                        PatchEarlierInstruction(pos, OpCodes.Ldarg_0, OpCodes.Ldc_R4, null, 0f);
-                        yield return new CodeInstruction(opcode: OpCodes.Call, operand: RandRangeFloat);
+                        if (localRandomOpCode.HasValue)
+                        {
+                            // Replace loading local random field with our first parameter
+                            PatchEarlierInstruction(instr, i, localRandomOpCode.Value, OpCodes.Ldc_R4, localRandomOperand, 0f);
+                            // Add a parameter for max value (since we don't have instructions to replace anymore)
+                            yield return new CodeInstruction(opcode: OpCodes.Ldc_R4, operand: 1f);
+                        }
+                        else
+                        {
+                            // Replace random loading from field into our rand parameters
+                            var pos = PatchEarlierInstruction(instr, i, OpCodes.Ldfld, OpCodes.Ldc_R4, typeof(System.Random), 1f);
+                            PatchEarlierInstruction(instr, pos, OpCodes.Ldarg_0, OpCodes.Ldc_R4, null, 0f);
+                        }
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = RandRangeFloat;
                     }
-                    else yield return ci;
+                    // We return the same instrucion, although with changed opcode and operand (if possible) to avoid issues with jumps
+                    // This shouldn't really be a possibility here, but it's better to be safe just in case
+                    yield return ci;
                 }
                 else yield return ci;
+            }
+        }
+
+        private static int PatchEarlierInstruction(IEnumerable<CodeInstruction> instr, int pos, OpCode codeFind, OpCode codeReplace, object operandFind = null, object operandReplace = null)
+        {
+            while (pos > 0)
+            {
+                pos--;
+
+                var currentOperation = instr.ElementAt(pos);
+                if (currentOperation.opcode == codeFind)
+                {
+                    if (operandFind == null || (operandFind is Type type && currentOperation.operand is FieldInfo info && info.FieldType == type) || (currentOperation.operand == operandFind))
+                    {
+                        currentOperation.opcode = codeReplace;
+                        currentOperation.operand = operandReplace;
+                        return pos;
+                    }
+                }
+            }
+
+            return 0;
+        }
+
+        private static void GetLdlocFromStloc(CodeInstruction instruction, out OpCode? randomCode, out object operand)
+        {
+            randomCode = null;
+            operand = null;
+
+            var opcode = instruction.opcode;
+
+            if (opcode == OpCodes.Stloc_0)
+                randomCode = OpCodes.Ldloc_0;
+            else if (opcode == OpCodes.Stloc_1)
+                randomCode = OpCodes.Ldloc_1;
+            else if (opcode == OpCodes.Stloc_2)
+                randomCode = OpCodes.Ldloc_2;
+            else if (opcode == OpCodes.Stloc_3)
+                randomCode = OpCodes.Ldloc_3;
+            else if (opcode == OpCodes.Stloc_S)
+            {
+                randomCode = OpCodes.Ldloc_S;
+                operand = instruction.operand;
+            }
+            else if (opcode == OpCodes.Stloc)
+            {
+                randomCode = OpCodes.Ldloc;
+                operand = instruction.operand;
             }
         }
         #endregion


### PR DESCRIPTION
The transpiler was modified to work in situations where System.Random is initialized inside of the method itself. It does not support methods that initialize System.Random several times, as I could not get it to work properly. I'll try working on it in the future.

Due to the issue I've mentioned, the Space Battle event is not patched and should be disabled by the user to avoid desyncs.

I've tested the patch for quite a bit, but considering the change is a rather serious one I'd recommend someone else test it first before accepting the pull request, just in case I've caused some issue with it or broke the patch itself before making the pull request.