### PR TITLE
Minor improvements to existing mod patches

### DIFF
--- a/Source/Mods/SparklingWorlds.cs
+++ b/Source/Mods/SparklingWorlds.cs
@@ -2,9 +2,9 @@
 using Multiplayer.API;
 using Verse;
 
-namespace Multiplayer.Compat.Mods
+namespace Multiplayer.Compat
 {
-    /// <summary>PowerSwitch by Albion</summary>
+    /// <summary>Sparkling Worlds by Albion</summary>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1123043922"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1195241161"/>
     [MpCompatFor("Albion.SparklingWorlds.Full")]

--- a/Source/Mods/VanillaCookingExpanded.cs
+++ b/Source/Mods/VanillaCookingExpanded.cs
@@ -25,7 +25,7 @@ namespace Multiplayer.Compat
             type = AccessTools.TypeByName("ItemProcessor.Command_SetQualityList");
             itemProcessorField = AccessTools.Field(type, "building");
             MP.RegisterSyncWorker<Command>(SyncSetTargetQuality, type, shouldConstruct: true);
-            MpCompat.RegisterSyncMethodsByIndex(type, "<ProcessInput>", Enumerable.Range(0, 7).ToArray());
+            MpCompat.RegisterSyncMethodsByIndex(type, "<ProcessInput>", Enumerable.Range(0, 8).ToArray());
 
             // Keep an eye on this in the future, seems like something the devs could combine into a single class at some point
             foreach (var ingredientNumber in new[] { "First", "Second", "Third" })

--- a/Source/Mods/VanillaFishingExpanded.cs
+++ b/Source/Mods/VanillaFishingExpanded.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
 using HarmonyLib;
@@ -31,10 +32,7 @@ namespace Multiplayer.Compat
                 mapField = AccessTools.Field(commandType, "map");
                 fishingZoneField = AccessTools.Field(commandType, "zone");
 
-                MP.RegisterSyncMethod(commandType, "<ProcessInput>b__4_0");
-                MP.RegisterSyncMethod(commandType, "<ProcessInput>b__4_1");
-                MP.RegisterSyncMethod(commandType, "<ProcessInput>b__4_2");
-
+                MpCompat.RegisterSyncMethodsByIndex(commandType, "<ProcessInput>", Enumerable.Range(0, 3).ToArray());
                 MP.RegisterSyncWorker<Command>(SyncFishingZoneChange, commandType, shouldConstruct: false);
             }
         }

--- a/Source/Mods/VanillaFurnitureExpandedPower.cs
+++ b/Source/Mods/VanillaFurnitureExpandedPower.cs
@@ -23,8 +23,7 @@ namespace Multiplayer.Compat
                 type = AccessTools.TypeByName("GasNetwork.CompGasStorage");
                 // Both these methods are calling (basically) the same method,
                 // but that method also has other callers that don't need syncing
-                MP.RegisterSyncMethod(type, "<CompGetGizmosExtra>b__15_0");
-                MP.RegisterSyncMethod(type, "<CompGetGizmosExtra>b__15_1");
+                MpCompat.RegisterSyncMethodsByIndex(type, "<CompGetGizmosExtra>", 0, 1);
 
                 type = AccessTools.TypeByName("VanillaPowerExpanded.CompPipeTank");
                 // This method is only called by 2 gizmos and nothing else (as far as I can tell)


### PR DESCRIPTION
This PR fixes namespace and name (in summary) for Sparkling Worlds, fixes the amount of patched methods in Vanilla Cooking Expanded, and makes Vanilla Fishing Expanded and Vanilla Furniture Expanded - Power both use the new `RegisterSyncMethodsByIndex` method to sync multiple methods at once.