### PR TITLE
Fixing Misc Robots patch

### DIFF
--- a/Source/Mods/MiscRobots.cs
+++ b/Source/Mods/MiscRobots.cs
@@ -13,7 +13,8 @@ namespace Multiplayer.Compat
         public MiscRobots(ModContentPack mod)
         {
             Type rechargestationType = AccessTools.TypeByName("AIRobot.X2_Building_AIRobotRechargeStation");
-         
+            Type robotType = AccessTools.TypeByName("AIRobot.X2_AIRobot");
+
             MP.RegisterSyncMethod(rechargestationType, "Button_CallAllBotsForShutdown");
             MP.RegisterSyncMethod(rechargestationType, "Button_CallBotForShutdown");
             MP.RegisterSyncMethod(rechargestationType, "Button_RepairDamagedRobot");
@@ -21,6 +22,11 @@ namespace Multiplayer.Compat
             MP.RegisterSyncMethod(rechargestationType, "Button_ResetDestroyedRobot");
             MP.RegisterSyncMethod(rechargestationType, "Button_SpawnAllAvailableBots");
             MP.RegisterSyncMethod(rechargestationType, "Button_SpawnBot");
+            
+            //Might as well sync the arrow gizmos in case some one actually click on it, because it is accessible by users,but not affecting gameplay
+            MP.RegisterSyncMethod(robotType, "Debug_ForceGotoDistance");
+            
+            MP.RegisterSyncMethod(rechargestationType, "AddRobotToContainer").SetContext(SyncContext.CurrentMap);
         }
         
     }


### PR DESCRIPTION
fixed desync on robot returning for recharging and tested, also synced 4 extra gizmos on the robot itself, though those gizmos are for debug purposes, they exist on the screen for some reason :P so I will sync those just in case someone clicked on it (they do cause desync before this patch), normal players will not interact with them in normal gameplay