### PR TITLE
Fixing a minor bug in Misc Robots patch 

### DIFF
--- a/Source/Mods/MiscRobots.cs
+++ b/Source/Mods/MiscRobots.cs
@@ -1,6 +1,8 @@
 ﻿using HarmonyLib;
 using Multiplayer.API;
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Verse;
 
 namespace Multiplayer.Compat
@@ -15,7 +17,8 @@ namespace Multiplayer.Compat
         {
             Type rechargestationType = AccessTools.TypeByName("AIRobot.X2_Building_AIRobotRechargeStation");
             Type robotType = AccessTools.TypeByName("AIRobot.X2_AIRobot");
-
+            Type robothelperType = AccessTools.TypeByName("AIRobot.AIRobot_Helper");
+            
             MP.RegisterSyncMethod(rechargestationType, "Button_CallAllBotsForShutdown");
             MP.RegisterSyncMethod(rechargestationType, "Button_CallBotForShutdown");
             MP.RegisterSyncMethod(rechargestationType, "Button_RepairDamagedRobot");
@@ -32,7 +35,38 @@ namespace Multiplayer.Compat
             PatchingUtilities.PatchPushPopRand("AIRobot.MoteThrowHelper:ThrowBatteryXYZ");
             PatchingUtilities.PatchPushPopRand("AIRobot.MoteThrowHelper:ThrowNoRobotSign");
 
-        }
+            MP.RegisterSyncWorker<Dictionary<ThingDef, int>>(SyncresourceDict);
+            MP.RegisterSyncMethod(robothelperType, "StartStationRepairJob");
 
+        }
+        private static void SyncresourceDict(SyncWorker sync, ref Dictionary<ThingDef, int> resourceDict)
+        {
+
+            if (sync.isWriting)
+            {
+                ThingDef[] dictKeys = new ThingDef[resourceDict.Count];
+                int[] dictValues = new int[resourceDict.Count];
+                
+                resourceDict.Keys.CopyTo(dictKeys, 0);
+                resourceDict.Values.CopyTo(dictValues, 0);
+                
+                sync.Write(dictKeys);
+                sync.Write(dictValues);
+            }
+            else
+            {
+                Dictionary<ThingDef, int> newDict = new Dictionary<ThingDef, int>();
+                
+                ThingDef[] dictKeys = sync.Read<ThingDef[]>();
+                int[] dictValues = sync.Read<int[]>();
+                
+                for (int i = 0; i < dictKeys.Length; i++)
+                {
+                    newDict.Add(dictKeys[i], dictValues[i]);
+                }
+
+                resourceDict = newDict;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixed a specific desync issue where forcing a pawn to repair a robot after it came back damaged without interacting with the repair robot gizmo first cause desync, tested and it works now