### PR TITLE
Quality Builder Multiplayer Compatibility and 2 new util method for MpCompat

### DIFF
--- a/Source/Mods/QualityBuilder.cs
+++ b/Source/Mods/QualityBuilder.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+using RimWorld;
+using System.Reflection;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Quality Builder by Hatti</summary>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=754637870"/>
+    [MpCompatFor("hatti.qualitybuilder")]
+    class QualityBuilder
+    {
+        public QualityBuilder(ModContentPack mod)
+        {
+            Type builderCompType = AccessTools.TypeByName("QualityBuilder.CompQualityBuilder");
+            Type toggleCommandType = AccessTools.TypeByName("QualityBuilder.CompQualityBuilder+ToggleCommand+<>c");
+            Type designatorType = AccessTools.TypeByName("QualityBuilder._Designator_SkilledBuilder+<>c");
+
+            Type[] argTypes = { typeof(QualityCategory) };
+
+            MethodInfo toggleCommandMethod = MpCompat.GetFirstMethodBySignature(toggleCommandType, argTypes);
+            MethodInfo designatorMethod = MpCompat.GetFirstMethodBySignature(designatorType, argTypes);
+
+            //my decompiler shows the method name is <get_RightClickFloatMenuOptions>b__3_0 
+            //while harmony saids it is <get_RightClickFloatMenuOptions>b__2_0, weird..."
+
+            MP.RegisterSyncWorker<object>(SyncTypes, toggleCommandType);
+            MP.RegisterSyncWorker<object>(SyncTypes, designatorType);
+
+            MP.RegisterSyncMethod(builderCompType, "ToggleSkilled");
+            MP.RegisterSyncMethod(toggleCommandMethod).SetContext(SyncContext.MapSelected);
+            MP.RegisterSyncMethod(designatorMethod);
+        
+        }
+
+        void SyncTypes(SyncWorker sync, ref object c)
+        {
+            if (sync.isWriting)
+            {
+                sync.Write(c.GetType());
+            } else
+            {
+                c = Activator.CreateInstance(sync.Read<Type>());
+            }
+        }
+    }
+}

--- a/Source/MpCompat.cs
+++ b/Source/MpCompat.cs
@@ -72,6 +72,47 @@ namespace Multiplayer.Compat
         public static ISyncMethod RegisterSyncMethodByIndex(Type type, string prefix, int index) {
             return MP.RegisterSyncMethod(MethodByIndex(type, prefix, index));
         }
+
+        /// <summary>Get the first method in the given type that matches the specified signature, return null if failed.</summary>
+        /// <param name="type">The type of the target method</param>
+        /// <param name="paramsType">The list of types of the target method's parameter</param>
+        public static MethodInfo GetFirstMethodBySignature(Type type, Type[] paramsType)
+        {
+            foreach (MethodInfo mi in AccessTools.GetDeclaredMethods(type))
+            {
+                List<Type> foundParamsType = new List<Type>();
+                if (mi.GetParameters().Length != 0) 
+                { 
+                    foreach (ParameterInfo pi in mi.GetParameters())
+                    {
+                        foundParamsType.Add(pi.ParameterType);
+                    }
+                }
+                if (paramsType.All(foundParamsType.Contains) && paramsType.Count() == foundParamsType.Count) { return mi; }
+            }
+            return null;
+        }
+
+        /// <summary>Get the first method in the given type that matches the specified signature, return null if failed.</summary>
+        /// <param name="type">The type of the target method</param>
+        /// <param name="paramsType">The list of types of the target method's parameter</param>
+        /// <param name="returnType">The return type of the target method</param>
+        public static MethodInfo GetFirstMethodBySignature(Type type, Type[] paramsType, Type returnType)
+        {
+            foreach (MethodInfo mi in AccessTools.GetDeclaredMethods(type))
+            {
+                List<Type> foundParamsType = new List<Type>();
+                if (mi.GetParameters().Length != 0)
+                {
+                    foreach (ParameterInfo pi in mi.GetParameters())
+                    {
+                        foundParamsType.Add(pi.ParameterType);
+                    }
+                }
+                if (paramsType.All(foundParamsType.Contains) && paramsType.Count() == foundParamsType.Count && returnType == mi.ReturnType) { return mi; }
+            }
+            return null;
+        }
     }
 
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]


### PR DESCRIPTION
2 new util method is used and added because we realized decompiler can sometimes give inconsistent compiler-generated method names, the first method is used in Quality Builder Compatibility(tested and worked), descriptions and usage are added to both methods. you can decide whether it should be added to MpCompat or just put it in this specific file instead