### PR TITLE
Fix VFE Security Module Jan 2021 Update Error

### DIFF
--- a/Source/Mods/VanillaFurnitureExpandedSecurity.cs
+++ b/Source/Mods/VanillaFurnitureExpandedSecurity.cs
@@ -88,7 +88,7 @@ namespace Multiplayer.Compat
                 var methods = new[]
                 {
                     // ArtilleryComp:TryResolveArtilleryCount is called by ArtilleryComp:CompTick
-                    "VFESecurity.ArtilleryComp:CompTick",
+                    "VFESecurity.ArtilleryComp:BombardmentTick",
                     "VFESecurity.ArtilleryComp:TryStartBombardment",
                     "VFESecurity.Building_Shield:Notify_EnergyDepleted",
                     "VFESecurity.Building_Shield:Draw",


### PR DESCRIPTION
Closes #56

Simply fixes the null exception caused by renaming the method. May still
have other updates/changes that need MP sync attention.