### PR TITLE
Add compatibility for Reunion

### DIFF
--- a/Source/Mods/Reunion.cs
+++ b/Source/Mods/Reunion.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Reunion by Kyrun</summary>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1985186461"/>
+    /// <see href="https://github.com/kyrun/rimworld-reunion"/>
+    [MpCompatFor("Kyrun.Reunion")]
+    public class Reunion
+    {
+        public Reunion(ModContentPack mod)
+        {
+            var methods = new[]
+            {
+                "Kyrun.Reunion.GameComponent:GetRandomAllyForSpawning",
+                "Kyrun.Reunion.GameComponent:TryScheduleNextEvent",
+                "Kyrun.Reunion.GameComponent:DecideAndDoEvent",
+            };
+            PatchingUtilities.PatchUnityRand(methods);
+        }
+    }
+}


### PR DESCRIPTION
Adding compatibility for Reunion mod https://steamcommunity.com/sharedfiles/filedetails/?id=1985186461
Just patching the random calls.
Was able to get through 3 reunion events in regular MP. Also attached validation below

Before
https://user-images.githubusercontent.com/33187058/105952341-119e8000-6037-11eb-971e-02eff955d1f5.mp4


After
https://user-images.githubusercontent.com/33187058/105952356-17946100-6037-11eb-9e19-20ad088e17e5.mp4



