### PR TITLE
Extracted part of VFE Security patch, applied it when Vanilla Weapons Expanded is enabled as well

### DIFF
--- a/Source/Mods/ExplosiveTrailsEffect.cs
+++ b/Source/Mods/ExplosiveTrailsEffect.cs
@@ -1,0 +1,30 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>ExplosiveTrailsEffect.dll is used (at least) by Vanilal Furniture Expanded - Security and Vanilla Weapons Expanded</summary>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1814383360"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1845154007"/>
+    /// <see href="https://github.com/AndroidQuazar/VanillaFurnitureExpanded-Security"/>
+    [MpCompatFor("VanillaExpanded.VWE")]
+    [MpCompatFor("VanillaExpanded.VFESecurity")]
+    public class ExplosiveTrailsEffect
+    {
+        private static bool isApplied = false;
+
+        public ExplosiveTrailsEffect(ModContentPack mod)
+        {
+            if (isApplied) return;
+
+            isApplied = true;
+
+            var methodNames = new[]
+            {
+                "ExplosiveTrailsEffect.ExhaustFlames:ThrowRocketExhaustFlame",
+                "ExplosiveTrailsEffect.SmokeThrowher:ThrowSmokeTrail",
+            };
+
+            PatchingUtilities.PatchPushPopRand(methodNames);
+        }
+    }
+}

--- a/Source/Mods/VanillaFurnitureExpandedSecurity.cs
+++ b/Source/Mods/VanillaFurnitureExpandedSecurity.cs
@@ -56,8 +56,6 @@ namespace Multiplayer.Compat
                     "NoCamShakeExplosions.DamageWorker_FlameNoCamShake:ExplosionAffectCell",
                     // Motes
                     "VFESecurity.ExtendedMoteMaker:SearchlightEffect",
-                    "ExplosiveTrailsEffect.ExhaustFlames:ThrowRocketExhaustFlame",
-                    "ExplosiveTrailsEffect.SmokeThrowher:ThrowSmokeTrail",
                 };
 
                 PatchingUtilities.PatchPushPopRand(AccessTools.Method(AccessTools.Inner(AccessTools.TypeByName("VFESecurity.Patch_Building_Trap"), "Spring"), "ShouldDestroy"));


### PR DESCRIPTION
The ExplosiveTrailsEffect.dll was causing issues while only being only referenced from .xml files, so I feel like it'd be safer to include a universal way to patch any mods using it.