### PR TITLE
Added compatibility for Vanilla Brewing Expanded and submods

### DIFF
--- a/Source/Mods/VanillaBrewingExpanded.cs
+++ b/Source/Mods/VanillaBrewingExpanded.cs
@@ -1,0 +1,17 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary> Vanilla Brewing Expanded by Oskar Potocki, Sarg Bjornson, Chowder</summary>
+    /// <see href="https://steamcommunity.com/workshop/filedetails/?id=2186560858"/>
+    /// <see href="https://github.com/juanosarg/VanillaBrewingExpanded"/>
+    [MpCompatFor("VanillaExpanded.VBrewE")]
+    class VanillaBrewingExpanded
+    {
+        public VanillaBrewingExpanded(ModContentPack mod)
+        {
+            PatchingUtilities.PatchSystemRand("VanillaBrewingExpanded.Plant_AutoProduce:TickLong");
+            PatchingUtilities.PatchSystemRandCtor("VanillaBrewingExpanded.Hediff_ConsumedCocktail");
+        }
+    }
+}


### PR DESCRIPTION
Indirectly fixes RNG desync in Vanilla Brewing Expanded - Coffees and Teas