### PR TITLE
Fixed Vanilla Expanded Framework/MVCF for the recent mod update

### DIFF
--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -149,9 +149,9 @@ namespace Multiplayer.Compat
                 MP.RegisterSyncMethod(type, "Toggle");
 
                 type = AccessTools.TypeByName("MVCF.Harmony.Gizmos");
-                MP.RegisterSyncDelegate(type, "<>c__DisplayClass4_0", "<GetGizmos_Postfix>b__1");
-                MP.RegisterSyncDelegate(type, "<>c__DisplayClass5_0", "<GetAttackGizmos_Postfix>b__4");
-                MP.RegisterSyncDelegate(type, "<>c__DisplayClass6_0", "<Pawn_GetGizmos_Postfix>b__0");
+                MP.RegisterSyncDelegate(type, "<>c__DisplayClass5_0", "<GetGizmos_Postfix>b__1"); // Fire at will
+                MP.RegisterSyncDelegate(type, "<>c__DisplayClass6_0", "<GetAttackGizmos_Postfix>b__4"); // Interrupt Attack
+                MP.RegisterSyncDelegate(type, "<>c__DisplayClass7_0", "<Pawn_GetGizmos_Postfix>b__0"); // Also interrupt Attack
             }
         }
 


### PR DESCRIPTION
I feel like we could use something like GetFirstMethodBySignature/RegisterSyncMethodByIndex/MethodsByIndex, but for inner classes/delegates. I could look into it soon, just I fear that I might try going in a roundabout way...