### PR TITLE
Compat for the 3 Corruption mods (Core, Psykers, Worship)

### DIFF
--- a/Source/Mods/CorruptionCore.cs
+++ b/Source/Mods/CorruptionCore.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Collections;
+using System.Reflection;
+using HarmonyLib;
+using Multiplayer.API;
+using RimWorld;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    [MpCompatFor("CptOhu.CorruptionCore")]
+    public class CorruptionCore
+    {
+        // ITab_Pawn_Soul
+        private static MethodInfo pawnSoulITabSoulToShowGetter;
+
+        // CompSoul
+        private static FieldInfo compSoulFavourTrackerField;
+        private static ISyncField compSoulAllowPrayingSync;
+        private static ISyncField compSoulShowPrayerSync;
+
+        // Dialog_SetPawnPantheon
+        private static Type setPawnPantheonDialogType;
+        private static FieldInfo setPawnPantheonDialogSoulField;
+
+        // Soul_FavourTracker
+        private static FieldInfo soulFavourTrackerFavoursField;
+
+        // FavourProgress
+        private static FieldInfo favourProgressFavourValueField;
+
+        public CorruptionCore(ModContentPack mod)
+        {
+            // ITab_Pawn_Soul - checkboxes to allow praying and show prayers
+            var type = AccessTools.TypeByName("Corruption.Core.Soul.ITab_Pawn_Soul");
+            pawnSoulITabSoulToShowGetter = AccessTools.PropertyGetter(type, "SoulToShow");
+            MP.RegisterSyncMethod(typeof(CorruptionCore), nameof(SyncFavourValue));
+            MpCompat.harmony.Patch(AccessTools.Method(type, "FillTab"),
+                prefix: new HarmonyMethod(typeof(CorruptionCore), nameof(PreFillTab)),
+                postfix: new HarmonyMethod(typeof(CorruptionCore), nameof(PostFillTab)));
+
+            type = AccessTools.TypeByName("Corruption.Core.Soul.CompSoul");
+            compSoulFavourTrackerField = AccessTools.Field(type, "FavourTracker");
+            compSoulAllowPrayingSync = MP.RegisterSyncField(type, "PrayerTracker/AllowPraying");
+            compSoulShowPrayerSync = MP.RegisterSyncField(type, "PrayerTracker/ShowPrayer");
+
+            setPawnPantheonDialogType = AccessTools.TypeByName("Corruption.Core.Dialog_SetPawnPantheon");
+            setPawnPantheonDialogSoulField = AccessTools.Field(setPawnPantheonDialogType, "soul");
+            MP.RegisterSyncMethod(setPawnPantheonDialogType, "SelectionChanged");
+            MP.RegisterSyncWorker<object>(SyncDialogSetPawnPantheon, setPawnPantheonDialogType);
+
+            type = AccessTools.TypeByName("Corruption.Core.Soul.Soul_FavourTracker");
+            soulFavourTrackerFavoursField = AccessTools.Field(type, "Favours");
+
+            type = AccessTools.TypeByName("Corruption.Core.Soul.FavourProgress");
+            favourProgressFavourValueField = AccessTools.Field(type, "favourValue");
+        }
+
+        private static void PreFillTab(ITab __instance, ref object[] __state)
+        {
+            if (MP.IsInMultiplayer)
+            {
+                __state = new object[2];
+
+                var soul = pawnSoulITabSoulToShowGetter.Invoke(__instance, Array.Empty<object>());
+
+                if (soul != null)
+                {
+                    MP.WatchBegin();
+                    compSoulAllowPrayingSync.Watch(soul);
+                    compSoulShowPrayerSync.Watch(soul);
+                    __state[0] = true;
+
+
+                    var favourTracker = compSoulFavourTrackerField.GetValue(soul);
+                    var favoursList = (IList)soulFavourTrackerFavoursField.GetValue(favourTracker);
+
+                    var favorValues = new float[favoursList.Count];
+                    for (int i = 0; i < favoursList.Count; i++)
+                        favorValues[i] = (float)favourProgressFavourValueField.GetValue(favoursList[i]);
+
+                    __state[1] = favorValues;
+                }
+                else __state[0] = false;
+            }
+        }
+
+        private static void PostFillTab(ITab __instance, ref object[] __state)
+        {
+            if (MP.IsInMultiplayer && (bool)__state[0])
+            {
+                MP.WatchEnd();
+
+                // Since we got non-null value in prefix, assume same here
+                var soul = pawnSoulITabSoulToShowGetter.Invoke(__instance, Array.Empty<object>());
+                var favourTracker = compSoulFavourTrackerField.GetValue(soul);
+
+                var previousFavourList = (float[])__state[1];
+                var favoursList = (IList)soulFavourTrackerFavoursField.GetValue(favourTracker);
+
+                for (int i = 0; i < favoursList.Count; i++)
+                {
+                    var newValue = (float)favourProgressFavourValueField.GetValue(favoursList[i]);
+                    var oldValue = previousFavourList[i];
+
+                    if (newValue != oldValue)
+                    {
+                        favourProgressFavourValueField.SetValue(favoursList[i], oldValue);
+                        SyncFavourValue((ThingComp)soul, i, newValue);
+                        // We could break here, but let's just keep going in case there's more than one changed
+                    }
+                }
+            }
+        }
+
+        private static void SyncFavourValue(ThingComp souldComp, int favourIndex, float value)
+        {
+            var favourTracker = compSoulFavourTrackerField.GetValue(souldComp);
+            var favoursList = (IList)soulFavourTrackerFavoursField.GetValue(favourTracker);
+            favourProgressFavourValueField.SetValue(favoursList[favourIndex], value);
+        }
+
+        private static void SyncDialogSetPawnPantheon(SyncWorker sync, ref object window)
+        {
+            if (sync.isWriting)
+            {
+                var compSoul = setPawnPantheonDialogSoulField.GetValue(window);
+                sync.Write((ThingComp)compSoul);
+            }
+            else
+            {
+                var compSoul = sync.Read<ThingComp>();
+                window = Activator.CreateInstance(setPawnPantheonDialogType, compSoul, null);
+            }
+        }
+    }
+}

--- a/Source/Mods/CorruptionCore.cs
+++ b/Source/Mods/CorruptionCore.cs
@@ -98,6 +98,7 @@ namespace Multiplayer.Compat
                 var previousFavourList = (float[])__state[1];
                 var favoursList = (IList)soulFavourTrackerFavoursField.GetValue(favourTracker);
 
+                // Check for changes, revert them (if any) and change them in synced method
                 for (int i = 0; i < favoursList.Count; i++)
                 {
                     var newValue = (float)favourProgressFavourValueField.GetValue(favoursList[i]);
@@ -108,6 +109,7 @@ namespace Multiplayer.Compat
                         favourProgressFavourValueField.SetValue(favoursList[i], oldValue);
                         SyncFavourValue((ThingComp)soul, i, newValue);
                         // We could break here, but let's just keep going in case there's more than one changed
+                        // There shouldn't be more than a single difference, but let's be safe
                     }
                 }
             }

--- a/Source/Mods/CorruptionPsykers.cs
+++ b/Source/Mods/CorruptionPsykers.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    [MpCompatFor("CptOhu.CorruptionPsyker")]
+    public class CorruptionPsykers
+    {
+        // DefDatabase<PsykerDisciplineDef>
+        private static MethodInfo getDefByShortHash;
+
+        // Window_Psyker
+        private static Type psykerWindowType;
+        private static FieldInfo psykerWindowCompField;
+
+        // CompPsyker
+        private static MethodInfo compPsykerTryLearnPowerMethod;
+        private static MethodInfo compPsykerAddXpMethod;
+        private static FieldInfo compPsykerMainDisciplineField;
+        private static FieldInfo compPsykerMinorDisciplinesField;
+        private static ISyncField compPsykerXpSyncField;
+
+        // PsykerDisciplineDef
+        private static FieldInfo psykerDisciplineDefAbilitiesField;
+
+        // Window_PsykerDiscipline
+        private static Type psykerDisciplineWindowType;
+        private static FieldInfo psykerDisciplineWindowCompField;
+        private static FieldInfo psykerDisciplineWindowSelectedDefField;
+
+        // Window_PsykerDisciplineMinor
+        private static Type psykerDisciplineMinorWindowType;
+
+        public CorruptionPsykers(ModContentPack mod)
+        {
+            // Window_PsykerDiscipline
+            psykerDisciplineWindowType = AccessTools.TypeByName("Corruption.Psykers.Window_PsykerDiscipline");
+            psykerDisciplineWindowCompField = AccessTools.Field(psykerDisciplineWindowType, "comp");
+            psykerDisciplineWindowSelectedDefField = AccessTools.Field(psykerDisciplineWindowType, "selectedDef");
+            MP.RegisterSyncMethod(psykerDisciplineWindowType, "ChoosePower");
+            MP.RegisterSyncWorker<object>(SyncPsykerDisciplineWindow, psykerDisciplineWindowType);
+
+
+            psykerDisciplineMinorWindowType = AccessTools.TypeByName("Corruption.Psykers.Window_PsykerDisciplineMinor");
+            MP.RegisterSyncMethod(psykerDisciplineMinorWindowType, "ChoosePower");
+            MP.RegisterSyncWorker<object>(SyncPsykerDisciplineMinorWindow, psykerDisciplineMinorWindowType);
+
+
+            LongEventHandler.ExecuteWhenFinished(LatePatch);
+        }
+
+        private static void LatePatch()
+        {
+            // Window_Psyker
+            psykerWindowType = AccessTools.TypeByName("Corruption.Psykers.Window_Psyker");
+            psykerWindowCompField = AccessTools.Field(psykerWindowType, "comp");
+            MP.RegisterSyncMethod(typeof(CorruptionPsykers), nameof(SyncedAddMinorDiscipline));
+
+            MpCompat.harmony.Patch(AccessTools.Method(psykerWindowType, nameof(Window.DoWindowContents)),
+                prefix: new HarmonyMethod(typeof(CorruptionPsykers), nameof(PrePsykerDoWindowContents)),
+                postfix: new HarmonyMethod(typeof(CorruptionPsykers), nameof(PostPsykerDoWindowContents)));
+
+            MP.RegisterSyncMethod(typeof(CorruptionPsykers), nameof(SyncedTryLearnPower));
+            MP.RegisterSyncMethod(typeof(CorruptionPsykers), nameof(SyncedInjectedAddXp));
+            MpCompat.harmony.Patch(AccessTools.Method(psykerWindowType, "DrawSelectedPower"),
+                transpiler: new HarmonyMethod(typeof(CorruptionPsykers), nameof(Transpiler)));
+
+            var psykerLearnablePowerType = AccessTools.TypeByName("Corruption.Psykers.PsykerLearnablePower");
+
+            var type = AccessTools.TypeByName("Corruption.Psykers.CompPsyker");
+            compPsykerTryLearnPowerMethod = AccessTools.Method(type, "TryLearnPower", new Type[] { psykerLearnablePowerType });
+            compPsykerAddXpMethod = AccessTools.Method(type, "AddXP");
+            compPsykerMainDisciplineField = AccessTools.Field(type, "MainDiscipline");
+            compPsykerMinorDisciplinesField = AccessTools.Field(type, "minorDisciplines");
+            compPsykerXpSyncField = MP.RegisterSyncField(type, "PsykerXP");
+
+            type = AccessTools.TypeByName("Corruption.Psykers.PsykerDisciplineDef");
+            psykerDisciplineDefAbilitiesField = AccessTools.Field(type, "abilities");
+
+            var database = typeof(DefDatabase<>).MakeGenericType(new Type[] { type });
+            getDefByShortHash = AccessTools.Method(database, "GetByShortHash");
+        }
+
+        private static void PrePsykerDoWindowContents(Window __instance, ref object[] __state)
+        {
+            if (MP.IsInMultiplayer)
+            {
+                var comp = psykerWindowCompField.GetValue(__instance);
+                // SyncField
+                MP.WatchBegin();
+                compPsykerXpSyncField.Watch(comp);
+
+                var list = (IList)compPsykerMinorDisciplinesField.GetValue(comp);
+                __state = new object[list.Count];
+                list.CopyTo(__state, 0);
+            }
+        }
+
+        private static void PostPsykerDoWindowContents(Window __instance, ref object[] __state)
+        {
+            if (MP.IsInMultiplayer)
+            {
+                MP.WatchEnd();
+
+                var comp = psykerWindowCompField.GetValue(__instance);
+                var list = (IList)compPsykerMinorDisciplinesField.GetValue(comp);
+
+                if (__state.Length != list.Count)
+                {
+                    foreach (var item in list)
+                    {
+                        if (!__state.Contains(item))
+                        {
+                            SyncedAddMinorDiscipline((ThingComp)comp, ((Def)item).shortHash);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void SyncedAddMinorDiscipline(ThingComp comp, ushort hash) 
+            => ((IList)compPsykerMinorDisciplinesField.GetValue(comp)).Add(getDefByShortHash.Invoke(null, new object[] { hash }));
+
+        private static void SyncPsykerDisciplineWindow(SyncWorker sync, ref object obj) => SyncPsykerDisciplineWindowAny(sync, ref obj, psykerDisciplineWindowType);
+
+        private static void SyncPsykerDisciplineMinorWindow(SyncWorker sync, ref object obj) => SyncPsykerDisciplineWindowAny(sync, ref obj, psykerDisciplineMinorWindowType);
+
+        private static void SyncPsykerDisciplineWindowAny(SyncWorker sync, ref object obj, Type windowType)
+        {
+            if (sync.isWriting)
+            {
+                sync.Write((ThingComp)psykerDisciplineWindowCompField.GetValue(obj));
+                sync.Write(((Def)psykerDisciplineWindowSelectedDefField.GetValue(obj)).shortHash);
+            }
+            else
+            {
+                var comp = sync.Read<ThingComp>();
+                var hash = sync.Read<ushort>();
+                var def = getDefByShortHash.Invoke(null, new object[] { hash });
+
+                // If the window exists, we try to find a window for the discipline field for that pawn
+                obj = Find.WindowStack.Windows.FirstOrDefault(x => x.GetType() == windowType && (ThingComp)psykerDisciplineWindowCompField.GetValue(x) == comp);
+
+                // If a specific player doesn't have the psyker menu open we'll have null here, we need to create it for our synced method
+                if (obj == null)
+                {
+                    // The Window_Psyker is needed for constructor and the synced method
+                    // It won't really do anything useful, but is needed
+                    var psykerWindow = Activator.CreateInstance(psykerWindowType, comp);
+                    obj = Activator.CreateInstance(windowType, comp, psykerWindow);
+                }
+
+                // Set the def to the correct one (someone might have another one selected, so make sure the same one is picked for everyone)
+                psykerDisciplineWindowSelectedDefField.SetValue(obj, def);
+            }
+        }
+
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instr)
+        {
+            foreach (var ci in instr)
+            {
+                if (ci.opcode == OpCodes.Callvirt)
+                {
+                    var method = (MethodInfo)ci.operand;
+
+                    if (method == compPsykerAddXpMethod)
+                    {
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = AccessTools.Method(typeof(CorruptionPsykers), nameof(SyncedInjectedAddXp));
+                    }
+                    else if (method == compPsykerTryLearnPowerMethod)
+                    {
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = AccessTools.Method(typeof(CorruptionPsykers), nameof(InjectedTryLearnPower));
+                    }
+                }
+            }
+
+            return instr;
+        }
+
+        private static void InjectedTryLearnPower(ThingComp comp, object selectedPower)
+        {
+            var disciplineDef = compPsykerMainDisciplineField.GetValue(comp);
+            var list = (IList)psykerDisciplineDefAbilitiesField.GetValue(disciplineDef);
+            var index = list.IndexOf(selectedPower);
+            
+            if (index >= 0)
+            {
+                SyncedTryLearnPower(comp, int.MinValue, index);
+            }
+            else
+            {
+                var defsList = (IList)compPsykerMinorDisciplinesField.GetValue(comp);
+                for (int i = 0; i < defsList.Count; i++)
+                {
+                    list = (IList)psykerDisciplineDefAbilitiesField.GetValue(defsList[i]);
+                    index = list.IndexOf(selectedPower);
+
+                    if (index >= 0)
+                    {
+                        SyncedTryLearnPower(comp, i, index);
+                        break;
+                    }
+                }
+            }
+        }
+
+        private static void SyncedTryLearnPower(ThingComp comp, int disciplineIndex, int abilityIndex)
+        {
+            IList abilityList;
+
+            if (disciplineIndex >= 0)
+            {
+                var defsList = (IList)compPsykerMinorDisciplinesField.GetValue(comp);
+                abilityList = (IList)psykerDisciplineDefAbilitiesField.GetValue(defsList[disciplineIndex]);
+            }
+            else
+            {
+                var disciplineDef = compPsykerMainDisciplineField.GetValue(comp);
+                abilityList = (IList)psykerDisciplineDefAbilitiesField.GetValue(disciplineDef);
+            }
+
+            compPsykerTryLearnPowerMethod.Invoke(comp, new object[] { abilityList[abilityIndex] });
+        }
+
+        private static void SyncedInjectedAddXp(ThingComp comp, int xp)
+        {
+            if (comp != null)
+                compPsykerAddXpMethod.Invoke(comp, new object[] { xp });
+        }
+    }
+}

--- a/Source/Mods/CorruptionWorship.cs
+++ b/Source/Mods/CorruptionWorship.cs
@@ -1,0 +1,479 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using Multiplayer.API;
+using RimWorld.Planet;
+using Verse;
+using Verse.AI.Group;
+
+namespace Multiplayer.Compat
+{
+    [MpCompatFor("CptVHOhu970.CorruptionWorship")]
+    public class CorruptionWorship
+    {
+        // DefDatabase<WonderDef>
+        private static MethodInfo getDefByShortHash;
+
+        // BuildingAltar
+        public static ISyncField altarNameSyncField; // Used by Dialog_RenameTemple
+        public static FieldInfo altarSermonTemplatesField; // Used for finding/syncing sermon using a BuildingAltar
+        public static MethodInfo altarEndSermonMethod;
+        public static MethodInfo altarTryStartSermonMethod;
+
+        // SermonTemplate
+        private static FieldInfo sermonTemplateNameField;
+        private static FieldInfo sermonTemplatePreferredStartTimeField;
+        private static FieldInfo sermonTemplateSermonDurationHoursField;
+        private static FieldInfo sermonTemplateActiveField;
+
+        // Dialog_AssignPreacher
+        private static Type assignPreacherType;
+        private static FieldInfo assignPreacherSermonField;
+        private static FieldInfo assignPreacherAltarField;
+
+        // Dialog_AssignAssistant
+        private static Type assignAssistantType;
+
+        // Inner class inside of TempleCardUtility
+        private static FieldInfo templeCardUtilityInnerAltarField;
+        private static FieldInfo templeCardUtilityInnerSermonField;
+
+        // MainTabWindow_Worship
+        // WonderWorker
+        private static FieldInfo wonderWorkerDefField;
+
+        // WonderWorker_Targetable
+        private static FieldInfo wonderWorkerTargetableTargetField;
+        private static FieldInfo wonderWorkerTargetableCanceledField;
+
+        // WonderDef
+        private static FieldInfo wonderDefWorkerIntField; // Not actually an int, it's just named like that
+
+        // Dialog_ReligiousRiot
+        private static Type religiousRiotType;
+
+        // Things we don't sync as they're unfinished, and seem to not be implemented yet:
+        // Dialog_StartRitual, which is created from BuildingSacrificialAltar
+
+        public CorruptionWorship(ModContentPack mod)
+        {
+            // BuildingAltar
+            {
+                var type = AccessTools.TypeByName("Corruption.Worship.BuildingAltar");
+                altarNameSyncField = MP.RegisterSyncField(type, "RoomName");
+                altarSermonTemplatesField = AccessTools.Field(type, "Templates");
+                altarEndSermonMethod = AccessTools.Method(type, "EndSermon");
+                altarTryStartSermonMethod = AccessTools.Method(type, "TryStartSermon");
+
+                // The class representing a sermon, with all the required data
+                type = AccessTools.TypeByName("Corruption.Worship.SermonTemplate");
+                sermonTemplateNameField = AccessTools.Field(type, "Name");
+                sermonTemplatePreferredStartTimeField = AccessTools.Field(type, "preferredStartTime");
+                sermonTemplateSermonDurationHoursField = AccessTools.Field(type, "SermonDurationHours");
+                sermonTemplateActiveField = AccessTools.Field(type, "Active");
+
+                // Dialog for renaming the altar, created from TempleCardUtility
+                type = AccessTools.TypeByName("Corruption.Worship.Dialog_RenameTemple");
+                MP.RegisterSyncMethod(typeof(CorruptionWorship), nameof(SyncSermonName));
+                MpCompat.harmony.Patch(AccessTools.Method(type, nameof(Window.DoWindowContents)),
+                    prefix: new HarmonyMethod(typeof(CorruptionWorship), nameof(RenameTemplePrefix)),
+                    postfix: new HarmonyMethod(typeof(CorruptionWorship), nameof(RenameTemplePostfix)));
+
+                // Dialog for renaming a specific sermon, created from TempleCardUtility
+                type = AccessTools.TypeByName("Corruption.Worship.Dialog_RenameSermon");
+                MpCompat.harmony.Patch(AccessTools.Method(type, "DoWindowContents"),
+                    prefix: new HarmonyMethod(typeof(CorruptionWorship), nameof(RenameSermonPrefix)),
+                    postfix: new HarmonyMethod(typeof(CorruptionWorship), nameof(RenameSermonPostfix)));
+
+                // Dialog used for assigning a preacher, created from TempleCardUtility
+                assignPreacherType = AccessTools.TypeByName("Corruption.Worship.Dialog_AssignPreacher");
+                assignPreacherAltarField = AccessTools.Field(assignPreacherType, "altar");
+                assignPreacherSermonField = AccessTools.Field(assignPreacherType, "sermon");
+                MP.RegisterSyncMethod(assignPreacherType, "AssignPawn");
+                MP.RegisterSyncMethod(assignPreacherType, "UnassignPawn");
+                MP.RegisterSyncWorker<Window>(SyncDialogAssignPreacher, assignPreacherType);
+
+                // Dialog used for assigning a preacher, you guessed it, created from TempleCardUtility
+                // This is a subclass of Dialog_AssignPreacher
+                assignAssistantType = AccessTools.TypeByName("Corruption.Worship.Dialog_AssignAssistant");
+                MP.RegisterSyncMethod(assignAssistantType, "AssignPawn");
+                MP.RegisterSyncMethod(assignAssistantType, "UnassignPawn");
+                MP.RegisterSyncWorker<Window>(SyncDialogAssignPreacher, assignAssistantType);
+            }
+
+            // MainTabWindow_Worship
+            {
+                // WonderWorker, does the work to execute the wonder defined in the MainTabWindow_Worship
+                var wonderWorkerType = AccessTools.TypeByName("Corruption.Worship.Wonders.WonderWorker");
+                var wonderWorkerTargetableType = AccessTools.TypeByName("Corruption.Worship.Wonders.WonderWorker_Targetable");
+                wonderWorkerDefField = AccessTools.Field(wonderWorkerType, "Def");
+                wonderWorkerTargetableTargetField = AccessTools.Field(wonderWorkerTargetableType, "target");
+                wonderWorkerTargetableCanceledField = AccessTools.Field(wonderWorkerTargetableType, "cancelled");
+                MP.RegisterSyncWorker<object>(SyncWonderWorker, wonderWorkerType, isImplicit: true);
+                MP.RegisterSyncWorker<object>(SyncWonderTargetableWorker, wonderWorkerTargetableType, isImplicit: true);
+                // Refunds the points if it was cancelled
+                MP.RegisterSyncMethod(wonderWorkerTargetableType, "CheckCancelled");
+
+                // Sync the method for each class inheriting from TryExecuteWonder
+                // If we ever want to sync the base class too, include .Concat(type) there
+                // But since all it does is returning false, we'll skip it
+                // We also check if it's not a subtype of WonderWorker_Targetable, as it uses TryDoEffectOnTarget method for the reward
+                // (and then we pray that there's not another class doing it in a special way)
+                foreach (var subtype in wonderWorkerType.AllSubclasses().Where(x => !x.IsAssignableFrom(wonderWorkerTargetableType)))
+                {
+                    // Include types for maximum safety
+                    var method = AccessTools.Method(subtype, "TryExecuteWonder", new[] { typeof(Def), typeof(int) });
+                    if (method != null)
+                        MP.RegisterSyncMethod(method);
+                }
+
+                // Same as before, but we sync it for classes that have a specific target
+                foreach (var subtype in wonderWorkerTargetableType.AllSubclasses())
+                {
+                    // Include types for maximum safety
+                    var method = AccessTools.Method(subtype, "TryDoEffectOnTarget", new[] { typeof(Def), typeof(int) });
+                    if (method != null)
+                        MP.RegisterSyncMethod(method);
+                }
+
+                // WonderDef, all we want is the field storing the WonderWorker for sync worker
+                var type = AccessTools.TypeByName("Corruption.Worship.Wonders.WonderDef");
+                wonderDefWorkerIntField = AccessTools.Field(type, "workerInt");
+
+                var database = typeof(DefDatabase<>).MakeGenericType(new Type[] { type });
+                getDefByShortHash = AccessTools.Method(database, "GetByShortHash");
+
+                // GlobalWorshipTracker, we sync favor usage when the user decides to purchase a wonder
+                type = AccessTools.TypeByName("Corruption.Worship.GlobalWorshipTracker");
+                MP.RegisterSyncMethod(type, "ConsumeFavourFor");
+            }
+
+            LongEventHandler.ExecuteWhenFinished(LatePatch);
+        }
+
+        private static void LatePatch()
+        {
+            // BuildingAltar continuation
+            {
+                // TempleCardUtility is used for UI drawing, called from BuildingAltar
+                var type = AccessTools.TypeByName("Corruption.Worship.TempleCardUtility");
+                MP.RegisterSyncDelegate(type, "<>c__DisplayClass4_1", "<OpenDedicationSelectMenu>b__1");
+                // We patch the modded method to intercept some of their calls that will need syncing and call them through our methods,
+                // as syncing the actual methods themselves will sync way too much (methods might/will be called often)
+                MpCompat.harmony.Patch(AccessTools.Method(type, "DrawSermonTemplate"),
+                    prefix: new HarmonyMethod(typeof(CorruptionWorship), nameof(DrawSermonTemplatePrefix)),
+                    postfix: new HarmonyMethod(typeof(CorruptionWorship), nameof(DrawSermonTemplatePostfix)),
+                    transpiler: new HarmonyMethod(typeof(CorruptionWorship), nameof(PatchDrawSermonTemplate)));
+
+                // The previous inner class (<>c__DisplayClass4_1) needs the following one to be synced too, but this one uses sermon
+                // which requires a bit more data to sync, so we make SyncWorker manually instead of using RegisterSyncDelegate
+                var inner = AccessTools.Inner(type, "<>c__DisplayClass4_0");
+                templeCardUtilityInnerAltarField = AccessTools.Field(inner, "altar");
+                templeCardUtilityInnerSermonField = AccessTools.Field(inner, "template");
+
+                MP.RegisterSyncMethod(typeof(CorruptionWorship), nameof(SyncedInterceptedReceiveMemo));
+                MP.RegisterSyncMethod(typeof(CorruptionWorship), nameof(SyncedInterceptedEndSermon));
+                MP.RegisterSyncMethod(typeof(CorruptionWorship), nameof(SyncedTryStartSermon)).SetDebugOnly();
+                MP.RegisterSyncMethod(typeof(CorruptionWorship), nameof(SyncSimpleSermonData));
+            }
+
+            // Dialog_ReligiousRiot, opened when there's enough pawns of different religion
+            // Should open for all players, so we assume we can get it/sync it using Find.WindowStack
+            {
+                religiousRiotType = AccessTools.TypeByName("Corruption.Worship.Dialog_ReligiousRiot");
+                MP.RegisterSyncMethod(religiousRiotType, "ChooseNewReligion");
+                MP.RegisterSyncMethod(religiousRiotType, "PreserveReligion");
+                MP.RegisterSyncWorker<Window>(SyncReligiousRiotDialog, religiousRiotType);
+            }
+
+            // Other stuff
+            {
+                // Rotating worship statue
+                var type = AccessTools.TypeByName("Corruption.Worship.Building_WorshipStatue");
+                MpCompat.RegisterSyncMethodByIndex(type, "<GetGizmos>", 0);
+
+                // Debug ring the bell
+                type = AccessTools.TypeByName("Corruption.Worship.CompBellTower");
+                MpCompat.RegisterSyncMethodByIndex(type, "<CompGetGizmosExtra>", 0).SetDebugOnly();
+
+                // Drop effigy
+                type = AccessTools.TypeByName("Corruption.Worship.CompShrine");
+                MP.RegisterSyncMethod(type, "DropEffigy");
+
+                // (Debug) force return from pilgrimage
+                type = AccessTools.TypeByName("Corruption.Worship.PilgrimageComp");
+                MpCompat.RegisterSyncMethodByIndex(type, "<GetCaravanGizmos>", 0).SetDebugOnly();
+            }
+        }
+
+        // Helper method for finding the sermon index inside of the (currently selected) altar
+        private static bool TryGetDataForSermon(object sermon, out Building altar, out int index)
+        {
+            if (Find.Selector.SingleSelectedThing is Building a)
+            {
+                altar = a;
+                return TryGetDataForSermon(sermon, altar, out index);
+            }
+            else
+            {
+                altar = null;
+                index = -1;
+                return false;
+            }
+        }
+
+        // Helper method for finding the sermon index inside of the altar
+        private static bool TryGetDataForSermon(object sermon, Building altar, out int index)
+        {
+            var list = (IList)altarSermonTemplatesField.GetValue(altar);
+            index = list.IndexOf(sermon);
+            return index >= 0;
+        }
+
+        // Helper method for getting the sermon out of an altar with specific index
+        private static object GetSermon(Building altar, int index)
+        {
+            var list = (IList)altarSermonTemplatesField.GetValue(altar);
+            return list[index];
+        }
+
+        // Used to watch for changes to the temple name
+        private static void RenameTemplePrefix(Building ___Altar)
+        {
+            if (MP.enabled)
+            {
+                MP.WatchBegin();
+                altarNameSyncField.Watch(___Altar);
+            }
+        }
+
+        private static void RenameTemplePostfix()
+        {
+            if (MP.enabled) MP.WatchEnd();
+        }
+
+        // Check for changes inside using widgets like checkboxes and sliders
+        // Everything else is changed using dialogs, windows, etc.
+        private static void DrawSermonTemplatePrefix(object sermon, ref object[] __state)
+        {
+            if (!MP.IsInMultiplayer) return;
+
+            __state = new object[]
+            {
+                sermonTemplatePreferredStartTimeField.GetValue(sermon),
+                sermonTemplateSermonDurationHoursField.GetValue(sermon),
+                sermonTemplateActiveField.GetValue(sermon),
+            };
+        }
+
+        private static void DrawSermonTemplatePostfix(Building altar, object sermon, ref object[] __state)
+        {
+            if (!MP.IsInMultiplayer) return;
+
+            if (TryGetDataForSermon(sermon, altar, out var index))
+            {
+                var startTime = (int)sermonTemplatePreferredStartTimeField.GetValue(sermon);
+                var duration = (float)sermonTemplateSermonDurationHoursField.GetValue(sermon);
+                var active = (bool)sermonTemplateActiveField.GetValue(sermon);
+
+                if (startTime != (int)__state[0] || duration != (float)__state[1] || active != (bool)__state[2])
+                {
+                    sermonTemplatePreferredStartTimeField.SetValue(sermon, __state[0]);
+                    sermonTemplateSermonDurationHoursField.SetValue(sermon, __state[1]);
+                    sermonTemplateActiveField.SetValue(sermon, __state[2]);
+
+                    SyncSimpleSermonData(altar, index, startTime, duration, active);
+                }
+            }
+        }
+
+        private static void SyncSimpleSermonData(Building altar, int index, int startTime, float duration, bool active)
+        {
+            var sermon = GetSermon(altar, index);
+
+            sermonTemplatePreferredStartTimeField.SetValue(sermon, startTime);
+            sermonTemplateSermonDurationHoursField.SetValue(sermon, duration);
+            sermonTemplateActiveField.SetValue(sermon, active);
+        }
+
+        // Used to watch for changes to the name of a specific sermon
+        private static void RenameSermonPrefix(object ___Sermon, ref string __state)
+        {
+            if (!MP.IsInMultiplayer) return;
+
+            __state = (string)sermonTemplateNameField.GetValue(___Sermon);
+        }
+
+        private static void RenameSermonPostfix(object ___Sermon, string __state)
+        {
+            if (!MP.IsInMultiplayer) return;
+
+            var name = (string)sermonTemplateNameField.GetValue(___Sermon);
+
+            if (name != __state && TryGetDataForSermon(___Sermon, out var altar, out var index))
+            {
+                sermonTemplateNameField.SetValue(___Sermon, __state);
+                SyncSermonName(altar, index, name);
+            }
+        }
+
+        // Used to sync the sermon name to all clients
+        private static void SyncSermonName(Building altar, int sermonIndex, string newSermonName) => sermonTemplateNameField.SetValue(GetSermon(altar, sermonIndex), newSermonName);
+
+        // Sync worker for the Dialog_AssignPreacher (and Dialog_AssignAssistant, as it's implicit worker)
+        private static void SyncDialogAssignPreacher(SyncWorker sync, ref Window obj)
+        {
+            if (sync.isWriting)
+            {
+                var sermon = assignPreacherSermonField.GetValue(obj);
+                var altar = assignPreacherAltarField.GetValue(obj) as Building;
+
+                if (TryGetDataForSermon(sermon, altar, out var index))
+                {
+                    sync.Write(index);
+                    sync.Write(altar);
+                    sync.Write(obj.GetType() == assignPreacherType);
+                }
+                else sync.Write(-1);
+            }
+            else
+            {
+                var index = sync.Read<int>();
+
+                if (index >= 0)
+                {
+                    var altar = sync.Read<Building>();
+                    var sermon = GetSermon(altar, index);
+                    var type = sync.Read<bool>() ? assignPreacherType : assignAssistantType;
+                    
+                    obj = Activator.CreateInstance(type, altar, sermon) as Window;
+                }
+            }
+        }
+
+        // Used for syncing inner, compiler-generated class inside of TempleCardUtility
+        private static void SyncTemplaCardUtilityInnerClass(SyncWorker sync, object obj)
+        {
+            if (sync.isWriting)
+            {
+                var altar = templeCardUtilityInnerAltarField.GetValue(obj) as Building;
+                var sermon = templeCardUtilityInnerSermonField.GetValue(obj);
+
+                if (TryGetDataForSermon(sermon, altar, out var index))
+                {
+                    sync.Write(index);
+                    sync.Write(altar);
+                }
+                else sync.Write(-1);
+            }
+            else
+            {
+                var index = sync.Read<int>();
+
+                if (index >= 0)
+                {
+                    var altar = sync.Read<Building>();
+                    templeCardUtilityInnerAltarField.SetValue(obj, altar);
+                    templeCardUtilityInnerSermonField.SetValue(obj, GetSermon(altar, index));
+                }
+            }
+        }
+
+        // Used for syncing WonderWorker
+        // Pretty easy, as WonderWorker has a field storing the def that uses it, and the def stores the worker
+        private static void SyncWonderWorker(SyncWorker sync, ref object obj)
+        {
+            if (sync.isWriting)
+                sync.Write(((Def)wonderWorkerDefField.GetValue(obj)).shortHash);
+            else
+                obj = wonderDefWorkerIntField.GetValue(getDefByShortHash.Invoke(null, new object[] { sync.Read<ushort>() }));
+        }
+
+        // Besides syncing a normal WonderWorker, we also need the info for target and if it was cancelled
+        private static void SyncWonderTargetableWorker(SyncWorker sync, ref object obj)
+        {
+            SyncWonderWorker(sync, ref obj);
+
+            if (sync.isWriting)
+            {
+                sync.Write((bool)wonderWorkerTargetableCanceledField.GetValue(obj));
+                sync.Write((TargetInfo)wonderWorkerTargetableTargetField.GetValue(obj));
+            }
+            else
+            {
+                wonderWorkerTargetableCanceledField.SetValue(obj, sync.Read<bool>());
+                wonderWorkerTargetableTargetField.SetValue(obj, sync.Read<TargetInfo>());
+            }
+        }
+
+        // Sync the religious riot dialog
+        // It should open up for all players, so we just get it from the WindowStack
+        private static void SyncReligiousRiotDialog(SyncWorker sync, ref Window obj)
+        {
+            if (!sync.isWriting)
+                obj = Find.WindowStack.Windows.First(x => x.GetType() == religiousRiotType);
+        }
+
+        // Patch out methods used by mod to our own, which will be synced
+        private static IEnumerable<CodeInstruction> PatchDrawSermonTemplate(IEnumerable<CodeInstruction> instr)
+        {
+            var receiveMemo = AccessTools.Method(typeof(Lord), nameof(Lord.ReceiveMemo));
+
+            foreach (var ci in instr)
+            {
+                if (ci.opcode == OpCodes.Callvirt)
+                {
+                    var operand = (MethodInfo)ci.operand;
+
+                    if (operand == receiveMemo)
+                    {
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = AccessTools.Method(typeof(CorruptionWorship), nameof(SyncedInterceptedReceiveMemo));
+                    }
+                    else if (operand == altarEndSermonMethod)
+                    {
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = AccessTools.Method(typeof(CorruptionWorship), nameof(SyncedInterceptedEndSermon));
+                    }
+                    else if (operand == altarTryStartSermonMethod)
+                    {
+                        ci.opcode = OpCodes.Call;
+                        ci.operand = AccessTools.Method(typeof(CorruptionWorship), nameof(InterceptedTryStartSermon));
+                    }
+                }
+
+                yield return ci;
+            }
+        }
+
+        private static void SyncedInterceptedReceiveMemo(Lord lord, string memo) => lord?.ReceiveMemo(memo);
+
+        private static void SyncedInterceptedEndSermon(Building altar)
+        {
+            if (altar != null)
+                altarEndSermonMethod.Invoke(altar, Array.Empty<object>());
+        }
+
+        // Don't sync this one as we can't easily sync the sermon
+        // Instead try getting it and then sync the other data required to get it
+        private static bool InterceptedTryStartSermon(Building altar, object sermon)
+        {
+            if (TryGetDataForSermon(sermon, altar, out var index))
+                SyncedTryStartSermon(altar, index);
+
+            // The place where we use this method doesn't care about the result
+            // So, we just return true
+            return true;
+        }
+
+        private static void SyncedTryStartSermon(Building altar, int index)
+        {
+            if (altarTryStartSermonMethod != null)
+                altarTryStartSermonMethod.Invoke(altar, new object[] { GetSermon(altar, index) });
+        }
+    }
+}


### PR DESCRIPTION
Since those mods are quite a bit there might be some issues left, but after quite a bit of testing I feel like the compat for them is stable (I have fixed all the issues I could find, with an exception of a minor bug).

Corruption Worship requires this PR to the MP to fully work: https://github.com/rwmt/Multiplayer/pull/152
Most of the features are going to work, the only one that won't work will be targetable rewards.

A small bug in Corruption Psykers that I've encountered, but haven't fixed is that each time the game is saved, each Psyker pawn will gain one more entry about their Psyker level in the inspector. This doesn't seem to have any effect on the game.

As I said earlier, everything I tested seemed to work fine, but again - I might have missed some stuff.