### PR TITLE
Compat for Clutter Structures

### DIFF
--- a/Source/Mods/ClutterStructures.cs
+++ b/Source/Mods/ClutterStructures.cs
@@ -1,0 +1,27 @@
+﻿using HarmonyLib;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Clutter Structures by mrofa and neronix17</summary>
+    /// <see href="https://github.com/neronix17/-O21-Clutter-Structure"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2008681009"/>
+    [MpCompatFor("neronix17.clutterstructures")]
+    class ClutterStructures
+    {
+        public ClutterStructures(ModContentPack mod)
+        {
+            StuffedFloorsCompat.Init();
+
+            MpCompat.harmony.Patch(
+                AccessTools.Method("Clutter_StructureWall.StructureDefGenerator:StuffGeneratrs"),
+                postfix: new HarmonyMethod(typeof(ClutterStructures), nameof(GetClutterStructureDefPostfix))
+                );
+        }
+
+        static void GetClutterStructureDefPostfix(ThingDef Wallzie)
+        {
+            StuffedFloorsCompat.defDatabaseAddMethod.Invoke(null, new object[] { Wallzie });
+        }
+    }
+}

--- a/Source/Mods/StuffedFloors.cs
+++ b/Source/Mods/StuffedFloors.cs
@@ -12,18 +12,26 @@ namespace Multiplayer.Compat
     [MpCompatFor("fluffy.stuffedfloors")]
     class StuffedFloorsCompat
     {
-        static MethodInfo defDatabaseAddMethod;
+        internal static MethodInfo defDatabaseAddMethod;
 
         public StuffedFloorsCompat(ModContentPack mod)
         {
-            Type[] generic = { typeof(BuildableDef) };
-
-            defDatabaseAddMethod = AccessTools.Method(typeof(DefDatabase<>).MakeGenericType(generic), "Add", generic);
+            Init();
 
             MpCompat.harmony.Patch(
                 AccessTools.Method("StuffedFloors.FloorTypeDef:GetStuffedTerrainDef"),
                 postfix: new HarmonyMethod(typeof(StuffedFloorsCompat), nameof(GetStuffedTerrainDefPosfix))
                 );
+        }
+
+        internal static void Init()
+        {
+            if (defDatabaseAddMethod == null)
+            {
+                Type[] generic = { typeof(BuildableDef) };
+
+                defDatabaseAddMethod = AccessTools.Method(typeof(DefDatabase<>).MakeGenericType(generic), "Add", generic);
+            }
         }
 
         static void GetStuffedTerrainDefPosfix(TerrainDef __result)


### PR DESCRIPTION
This patch reuses the field created by Stuffed Floors patch, as the patch itself is very similar and can use it as well. This was mostly done to avoid having another field which isn't exactly needed.