### PR TITLE
Common sense update

### DIFF
--- a/Source/Mods/CommonSense.cs
+++ b/Source/Mods/CommonSense.cs
@@ -19,8 +19,10 @@ namespace Multiplayer.Compat
         {
             manualUnloadEnabledField = AccessTools.Field(AccessTools.TypeByName("CommonSense.Settings"), "gui_manual_unload");
             var type = AccessTools.TypeByName("CommonSense.CompUnloadChecker");
+            // We need to make a sync worker for this Comp, as it is initialized dynamically and might not exists at the time
             MP.RegisterSyncWorker<ThingComp>(SyncComp, type);
             shouldUnloadSyncField = MP.RegisterSyncField(AccessTools.Field(type, "ShouldUnload"));
+            // The GetChecker method either gets an existing, or creates a new comp
             getCompUnlockerCheckerMethod = AccessTools.Method(type, "GetChecker");
 
             MpCompat.harmony.Patch(AccessTools.Method("CommonSense.Utility:DrawThingRow"),
@@ -51,6 +53,7 @@ namespace Multiplayer.Compat
             if (sync.isWriting)
                 sync.Write<Thing>(thing.parent);
             else
+                // Get existing or create a new comp
                 thing = (ThingComp)getCompUnlockerCheckerMethod.Invoke(null, new object[] { sync.Read<Thing>(), false, false });
         }
     }

--- a/Source/Mods/CommonSense.cs
+++ b/Source/Mods/CommonSense.cs
@@ -23,9 +23,11 @@ namespace Multiplayer.Compat
             shouldUnloadSyncField = MP.RegisterSyncField(AccessTools.Field(type, "ShouldUnload"));
             getCompUnlockerCheckerMethod = AccessTools.Method(type, "GetChecker");
 
-            MpCompat.harmony.Patch(AccessTools.Method("RimWorld.ITab_Pawn_Gear:DrawThingRow"),
+            MpCompat.harmony.Patch(AccessTools.Method("CommonSense.Utility:DrawThingRow"),
                 prefix: new HarmonyMethod(typeof(CommonSense), nameof(CommonSensePatchPrefix)),
                 postfix: new HarmonyMethod(typeof(CommonSense), nameof(CommonSensePatchPostix)));
+
+            PatchingUtilities.PatchUnityRand("CommonSense.JobGiver_Wander_TryGiveJob_CommonSensePatch:Postfix", false);
         }
 
         private static void CommonSensePatchPrefix(Thing thing)


### PR DESCRIPTION
-Patched Unity RNG to use Verse instead.
-Changed the patched method for unload watching - this change makes the unload feature compatible with RPG Style Inventory Revamped.
-Removed a check if unload feature is enabled - the check is unneeded (and possibly issue causing), as the unload feature still works even if the button itself is disabled. This will make it so when some of the players have it on while others have it off it'll still work.
-Added some comments to the code