### PR TITLE
Added partial compat for Vanilla Traits Expanded

### DIFF
--- a/Source/Mods/VanillaTraitsExpanded.cs
+++ b/Source/Mods/VanillaTraitsExpanded.cs
@@ -1,0 +1,14 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Vanilla Traits Expanded by Oskar Potocki, Taranchuk, Chowder</summary>
+    /// <see href="https://github.com/AndroidQuazar/VanillaTraitsExpanded"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2296404655"/>
+    [MpCompatFor("VanillaExpanded.VanillaTraitsExpanded")]
+    public class VanillaTraitsExpanded
+    {
+        public VanillaTraitsExpanded(ModContentPack mod) =>
+            PatchingUtilities.PatchPushPopRand("VanillaTraitsExpanded.TraitsManager:GameComponentTick");
+    }
+}


### PR DESCRIPTION
This might not be 100% needed, however from my personal testing it was causing issues.

Even with this patch the trait Absent Minded is going to cause issues and desync so, as I mentioned earlier, this is a partial compat.