### PR TITLE
Updated List of Supported Mods

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -10,6 +10,7 @@
     Mod Support:
     - [KV] RimFridge
     - [KV] Path Avoid
+    - [O21] Clutter Structures
     - Alpha Animals
     - Alpha Biomes
     - Animals Logic
@@ -64,6 +65,7 @@
     - Vanilla Furniture Expanded - Power
     - Vanilla Furniture Expanded - Security
     - Vanilla Hair Expanded
+    - Vanilla Plants Expanded - Auto Plow Patch
     - Vanilla Social Interactions Expanded
     - Vanilla Traits Expanded (Partial Support)
     - Vanilla Weapons Expanded - Laser

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Support added to these mods | _
 --- | ---
 [KV] RimFridge                                     | [![url][repo]](https://github.com/KiameV/rimworld-rimfridge)
 [KV] Path Avoid                                    | [![url][repo]](https://github.com/KiameV/rimworld-pathavoid)
+[O21] Clutter Structures                           | [![url][repo]](https://github.com/neronix17/-O21-Clutter-Structure)
 Alpha Animals                                      | [![url][repo]](https://github.com/juanosarg/AlphaAnimals)
 Alpha Biomes                                       | [![url][repo]](https://github.com/juanosarg/AlphaBiomes)
 Animals Logic                                      | [![url][repo]](https://github.com/quicksilverfox/RimworldMods/tree/master/AnimalsLogic)
@@ -67,6 +68,7 @@ Vanilla Furniture Expanded - Farming               | [![url][steam]](https://ste
 Vanilla Furniture Expanded - Power                 | [![url][repo]](https://github.com/AndroidQuazar/VanillaFurnitureExpanded-Power)
 Vanilla Furniture Expanded - Security              | [![url][repo]](https://github.com/AndroidQuazar/VanillaFurnitureExpanded-Security)
 Vanilla Hair Expanded                              | [![url][repo]](https://github.com/AndroidQuazar/VanillaHairExpanded)
+Vanilla Plants Expanded - Auto Plow Patch          | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=2497914485)
 Vanilla Social Interactions Expanded               | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=2439736083)
 Vanilla Traits Expanded (Partial Support)          | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=2296404655)
 Vanilla Weapons Expanded - Laser                   | [![url][repo]](https://github.com/AndroidQuazar/VanillaWeaponsExpanded-Laser)


### PR DESCRIPTION
Just adding a couple more mods Sokyran added. 

Question I have though is that in the last update Swept added _"(Partial Support)"_ to Vanilla Traits Expanded since it indeed has partial support. I think a few more mods also only have partial support or at least according to the Mod Check List don't have full compat ratings yet even with MP Compat. Should  _"(Partial Support)"_ be added to those as well? 