### PR TITLE
Fixed loading of referenced compat classes using uppercase mod ID

### DIFF
--- a/Source/MpCompatLoader.cs
+++ b/Source/MpCompatLoader.cs
@@ -36,7 +36,7 @@ namespace Multiplayer.Compat
                     .FirstOrDefault(a => a.Constructor.DeclaringType.Name == nameof(MpCompatForAttribute));
                 if (attr == null) continue;
 
-                var modId = (string)attr.ConstructorArguments.First().Value;
+                var modId = ((string)attr.ConstructorArguments.First().Value).ToLower();
                 var mod = LoadedModManager.RunningMods.FirstOrDefault(m => m.PackageId.NoModIdSuffix() == modId);
                 if (mod == null)
                     asm.MainModule.Types.Remove(t);


### PR DESCRIPTION
Right now it would fail if the referenced mod would use attribute like :
```csharp
[MpCompatFor("OskarPotocki.VanillaFactionsExpanded.Core")]
```
The same operation is done as well at line 61, when actually loading the classes.