### PR TITLE
Made access to Harmony instance public for patches using referenced dll files.

### DIFF
--- a/Source/MpCompat.cs
+++ b/Source/MpCompat.cs
@@ -12,7 +12,7 @@ namespace Multiplayer.Compat
     public class MpCompat : Mod
     {
         const string REFERENCES_FOLDER = "References";
-        internal static readonly Harmony harmony = new Harmony("rimworld.multiplayer.compat");
+        public static readonly Harmony harmony = new Harmony("rimworld.multiplayer.compat");
 
         public MpCompat(ModContentPack content) : base(content)
         {


### PR DESCRIPTION
Alternatively we could use another instance for the referenced project, however I feel this would be somewhat pointless.