### PR TITLE
Display the exception itself if the InnerException is null in MpCompatLoader

### DIFF
--- a/Source/MpCompatLoader.cs
+++ b/Source/MpCompatLoader.cs
@@ -68,7 +68,7 @@ namespace Multiplayer.Compat
                     Activator.CreateInstance(action.type, action.mod);
                     Log.Message($"MPCompat :: Initialized compatibility for {action.mod.PackageId}");
                 } catch(Exception e) {
-                    Log.Error($"MPCompat :: Exception loading {action.mod.PackageId}: {e.InnerException}");
+                    Log.Error($"MPCompat :: Exception loading {action.mod.PackageId}: {e.InnerException ?? e}");
                 }
             }
         }


### PR DESCRIPTION
MissingMethodException when constructor is private is one such exception where it was null, which meant it was not displaying any information at all related to it.