### PR TITLE
Replaced FieldInfo with FieldRefAccess wherever possible

### DIFF
--- a/Source/Mods/AlphaBiomes.cs
+++ b/Source/Mods/AlphaBiomes.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq;
-using System.Reflection;
 using HarmonyLib;
 using Multiplayer.API;
 using Verse;
@@ -12,13 +11,13 @@ namespace Multiplayer.Compat
     [MpCompatFor("sarg.alphabiomes")]
     class AlphaBiomes
     {
-        private static FieldInfo buildingField;
+        private static AccessTools.FieldRef<object, Building> buildingField;
 
         public AlphaBiomes(ModContentPack mod)
         {
             var type = AccessTools.TypeByName("AlphaBiomes.Command_SetStoneType");
 
-            buildingField = AccessTools.Field(type, "building");
+            buildingField = AccessTools.FieldRefAccess<Building>(type, "building");
             // SyncWorker needed as the <ProcessInput> methods require syncing of the `building` field
             MP.RegisterSyncWorker<Command>(SyncSetStoneType, type, shouldConstruct: true);
             MpCompat.RegisterLambdaMethod(type, "ProcessInput", Enumerable.Range(0, 6).ToArray());
@@ -37,9 +36,9 @@ namespace Multiplayer.Compat
         private static void SyncSetStoneType(SyncWorker sync, ref Command command)
         {
             if (sync.isWriting)
-                sync.Write(buildingField.GetValue(command) as Thing);
+                sync.Write(buildingField(command));
             else
-                buildingField.SetValue(command, sync.Read<Thing>());
+                buildingField(command) = sync.Read<Building>();
         }
     }
 }

--- a/Source/Mods/AvoidFriendlyFire.cs
+++ b/Source/Mods/AvoidFriendlyFire.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Linq;
-using System.Reflection;
 
 using HarmonyLib;
 using Multiplayer.API;
@@ -17,16 +15,12 @@ namespace Multiplayer.Compat
     public class AvoidFriendlyFire
     {
         static IDictionary extendedPawnDataDictionary;
-        static Type extendedPawnDataType;
-        static FieldInfo avoidFriendlyFireField;
 
         public AvoidFriendlyFire(ModContentPack mod)
         {
             {
-                var type = extendedPawnDataType = AccessTools.TypeByName("AvoidFriendlyFire.ExtendedPawnData");
+                var type = AccessTools.TypeByName("AvoidFriendlyFire.ExtendedPawnData");
                 MP.RegisterSyncWorker<object>(SyncWorkerFor, type);
-
-                avoidFriendlyFireField = type.GetField("AvoidFriendlyFire");
             }
             {
                 MpCompat.RegisterLambdaDelegate("AvoidFriendlyFire.Pawn_DraftController_GetGizmos_Patch", "Postfix", 1);

--- a/Source/Mods/ChoiceOfPsycasts.cs
+++ b/Source/Mods/ChoiceOfPsycasts.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using HarmonyLib;
 using Multiplayer.API;
 using Verse;
@@ -12,29 +11,28 @@ namespace Multiplayer.Compat
     public class ChoiceOfPsycastsCompat
     {
         static Type learnPsycastsType;
-        static FieldInfo levelField, parentField;
+        static AccessTools.FieldRef<object, int> levelField;
+        static AccessTools.FieldRef<object, Pawn> parentField;
         
         public ChoiceOfPsycastsCompat(ModContentPack mod)
         {
             var type = learnPsycastsType = AccessTools.TypeByName("RimWorld.ChoiceOfPsycasts.LearnPsycasts");
-            
-            MP.RegisterSyncDelegate(type, "<>c__DisplayClass3_0", "<Choice>b__0");
 
-            levelField = AccessTools.Field(type, "Level");
-            parentField = AccessTools.Field(type, "Parent");
+            MpCompat.RegisterLambdaDelegate(type, "Choice", 1);
+            MpCompat.RegisterLambdaDelegate(type, "ChoiceCustom", 1);
+
+            levelField = AccessTools.FieldRefAccess<int>(type, "Level");
+            parentField = AccessTools.FieldRefAccess<Pawn>(type, "Parent");
             MP.RegisterSyncWorker<Command_Action>(SyncLearnPsycasts, type);
         }
 
         static void SyncLearnPsycasts(SyncWorker sync, ref Command_Action command)
         {
             if (sync.isWriting) {
-                sync.Write((int)levelField.GetValue(command));
-                sync.Write((Pawn)parentField.GetValue(command));
+                sync.Write(levelField(command));
+                sync.Write(parentField(command));
             } else {
-                command = (Command_Action) Activator.CreateInstance(learnPsycastsType, new object[] {
-                    sync.Read<int>(),
-                    sync.Read<Pawn>()
-                });
+                command = (Command_Action) Activator.CreateInstance(learnPsycastsType, sync.Read<int>(), sync.Read<Pawn>());
             }
         }
     }    

--- a/Source/Mods/Immortals.cs
+++ b/Source/Mods/Immortals.cs
@@ -1,6 +1,5 @@
 ﻿using HarmonyLib;
 using System;
-using System.Reflection;
 using Verse;
 
 namespace Multiplayer.Compat
@@ -12,13 +11,11 @@ namespace Multiplayer.Compat
     class Immortals
     {
         private static Type immortalComponent;
-        private static MethodInfo immortalsUpdate;
         private static bool shouldCall = false;
 
         public Immortals(ModContentPack mod)
         {
             immortalComponent = AccessTools.TypeByName("Immortals.Immortal_Component");
-            immortalsUpdate = AccessTools.Method(immortalComponent, "GameComponentUpdate");
             MpCompat.harmony.Patch(AccessTools.Method("Immortals.Immortal_Component:GameComponentUpdate"), prefix: new HarmonyMethod(typeof(Immortals), nameof(GameComponentUpdatePrefix)));
             MpCompat.harmony.Patch(AccessTools.Method("Verse.GameComponent:GameComponentTick"), prefix: new HarmonyMethod(typeof(Immortals), nameof(GameComponentTickPrefix)));
         }
@@ -30,7 +27,7 @@ namespace Multiplayer.Compat
             if (__instance.GetType() == immortalComponent)
             {
                 shouldCall = true;
-                immortalsUpdate.Invoke(__instance, Array.Empty<object>());
+                __instance.GameComponentUpdate();
                 shouldCall = false;
             }
         }

--- a/Source/Mods/PathAvoid.cs
+++ b/Source/Mods/PathAvoid.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
-
+using System.Reflection.Emit;
 using HarmonyLib;
 using Multiplayer.API;
+using UnityEngine;
 using Verse;
 namespace Multiplayer.Compat
 {
@@ -13,33 +15,130 @@ namespace Multiplayer.Compat
     [MpCompatFor("pathavoid.kv.rw")]
     public class PathAvoidCompat
     {
-        static Type PathAvoidDefType;
-        static Type Designator_PathAvoidType;
-        static FieldInfo PathAvoidDefField;
+        private static Type pathAvoidDefType;
+        private static Type designator_PathAvoidType;
+        private static Type pathAvoidGridType;
+
+        private static AccessTools.FieldRef<object, int> levelField;
+        private static AccessTools.FieldRef<object, Def> pathAvoidDefField;
+        private static AccessTools.FieldRef<object, TerrainDef> selectedTerrainDefField;
+        private static AccessTools.FieldRef<object, Def> selectedPathAvoidDefField;
+        private static AccessTools.FieldRef<object, Def> selectedPathAvoidDefForResetField;
+
+        private static MethodInfo pathAvoidGridSetValueMethod;
 
         public PathAvoidCompat(ModContentPack mod)
         {
-            PathAvoidDefType = AccessTools.TypeByName("PathAvoid.PathAvoidDef");
-            Designator_PathAvoidType = AccessTools.TypeByName("PathAvoid.Designator_PathAvoid");
-            PathAvoidDefField = AccessTools.Field(Designator_PathAvoidType, "def");
+            pathAvoidDefType = AccessTools.TypeByName("PathAvoid.PathAvoidDef");
+            levelField = AccessTools.FieldRefAccess<int>(pathAvoidDefType, "level");
 
-            MP.RegisterSyncWorker<Designator>(PathAvoidDesignatorSyncWorker, Designator_PathAvoidType);
+            designator_PathAvoidType = AccessTools.TypeByName("PathAvoid.Designator_PathAvoid");
+            pathAvoidDefField = AccessTools.FieldRefAccess<Def>(designator_PathAvoidType, "def");
+
+            MP.RegisterSyncWorker<Designator>(PathAvoidDesignatorSyncWorker, designator_PathAvoidType);
+
+            var type = AccessTools.TypeByName("PathAvoid.MapSettingsDialog");
+            selectedTerrainDefField = AccessTools.FieldRefAccess<TerrainDef>(type, "selectedTerrainDef");
+            selectedPathAvoidDefField = AccessTools.FieldRefAccess<Def>(type, "selectedPathAvoidDef");
+            selectedPathAvoidDefForResetField = AccessTools.FieldRefAccess<Def>(type, "selectedPathAvoidDefForReset");
+            MpCompat.harmony.Patch(AccessTools.Method(type, nameof(Window.DoWindowContents)),
+                transpiler: new HarmonyMethod(typeof(PathAvoidCompat), nameof(ReplaceAcceptButtons)));
+
+            pathAvoidGridType = AccessTools.TypeByName("PathAvoid.PathAvoidGrid");
+            pathAvoidGridSetValueMethod = AccessTools.Method(pathAvoidGridType, "SetValue", new[] { typeof(int), typeof(byte) });
+
+            MP.RegisterSyncMethod(typeof(PathAvoidCompat), nameof(SyncedSetAllToDef));
         }
 
-        static void PathAvoidDesignatorSyncWorker(SyncWorker sw, ref Designator designator)
+        private static void PathAvoidDesignatorSyncWorker(SyncWorker sw, ref Designator designator)
         {
             Def def = null;
 
-            if (sw.isWriting) {
-                def = (Def) PathAvoidDefField.GetValue(designator);
+            if (sw.isWriting)
+            {
+                def = pathAvoidDefField(designator);
 
                 sw.Write(def.defName);
-            } else {
+            }
+            else
+            {
                 string defName = sw.Read<string>();
 
-                def = GenDefDatabase.GetDef(PathAvoidDefType, defName, false);
+                def = GenDefDatabase.GetDef(pathAvoidDefType, defName, false);
 
-                designator = (Designator) Activator.CreateInstance(Designator_PathAvoidType, new object[] { def });
+                designator = (Designator)Activator.CreateInstance(designator_PathAvoidType, def);
+            }
+        }
+
+        private static bool SetAllTerrainToDefButton(Rect rect, string label, bool drawBackground, bool doMouseoverSounds, bool active, Window instance)
+        {
+            var result = Widgets.ButtonText(rect, label, drawBackground, doMouseoverSounds, active);
+
+            if (!MP.IsInMultiplayer)
+                return result;
+
+            if (result)
+                SyncedSetAllToDef(Current.Game.CurrentMap, (byte)levelField(selectedPathAvoidDefField(instance)), selectedTerrainDefField(instance));
+
+            return false;
+        }
+
+        private static bool SetAllToDefButton(Rect rect, string label, bool drawBackground, bool doMouseoverSounds, bool active, Window instance)
+        {
+            var result = Widgets.ButtonText(rect, label, drawBackground, doMouseoverSounds, active);
+
+            if (!MP.IsInMultiplayer)
+                return result;
+
+            if (result)
+                SyncedSetAllToDef(Current.Game.CurrentMap, (byte)levelField(selectedPathAvoidDefForResetField(instance)));
+
+            return false;
+        }
+
+        private static void SyncedSetAllToDef(Map map, byte pathAvoidLevel, TerrainDef filter = null)
+        {
+            var comp = map.GetComponent(pathAvoidGridType);
+
+            if (comp != null)
+            {
+                for (var i = 0; i < map.terrainGrid.topGrid.Length; i++)
+                {
+                    if (filter == null || map.terrainGrid.TerrainAt(i) == filter)
+                    {
+                        pathAvoidGridSetValueMethod.Invoke(comp, new object[] { i, pathAvoidLevel });
+                    }
+                }
+            }
+            else
+                Log.Error("failed to get path avoid grid");
+        }
+
+        private static IEnumerable<CodeInstruction> ReplaceAcceptButtons(IEnumerable<CodeInstruction> instr)
+        {
+            var buttonMethod = AccessTools.Method(typeof(Widgets), nameof(Widgets.ButtonText), new[] { typeof(Rect), typeof(string), typeof(bool), typeof(bool), typeof(bool) });
+            var isAccept = false;
+            var isSecond = false;
+
+            foreach (var ci in instr)
+            {
+                if (isAccept && ci.opcode == OpCodes.Call && (MethodInfo)ci.operand == buttonMethod)
+                {
+                    // Add instance of the object as parameter
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+
+                    if (isSecond)
+                        ci.operand = AccessTools.Method(typeof(PathAvoidCompat), nameof(SetAllToDefButton));
+                    else
+                        ci.operand = AccessTools.Method(typeof(PathAvoidCompat), nameof(SetAllTerrainToDefButton));
+
+                    isAccept = false;
+                    isSecond = true;
+                }
+                else if (ci.opcode == OpCodes.Ldstr && (string)ci.operand == "Accept")
+                    isAccept = true;
+
+                yield return ci;
             }
         }
     }

--- a/Source/Mods/SRTSExpanded.cs
+++ b/Source/Mods/SRTSExpanded.cs
@@ -14,7 +14,7 @@ namespace Multiplayer.Compat
     {
         private static bool isSyncing = false;
         private static MethodInfo tryLaunchMethod;
-        private static FieldInfo caravanField;
+        private static AccessTools.FieldRef<object, Caravan> caravanField;
         private static ISyncField bombTypeSync;
 
         public SRTSExpanded(ModContentPack mod)
@@ -40,7 +40,7 @@ namespace Multiplayer.Compat
         {
             // Launching the shuttle
             var type = AccessTools.TypeByName("SRTS.CompLaunchableSRTS");
-            caravanField = AccessTools.Field(type, "carr");
+            caravanField = AccessTools.FieldRefAccess<Caravan>(type, "carr");
             tryLaunchMethod = AccessTools.Method(type, "TryLaunch");
 
             MpCompat.harmony.Patch(tryLaunchMethod, prefix: new HarmonyMethod(typeof(SRTSExpanded), nameof(PreTryLaunch)));
@@ -72,7 +72,7 @@ namespace Multiplayer.Compat
 
             isSyncing = true;
 
-            var caravanFieldValue = caravanField.GetValue(__instance) as Caravan;
+            var caravanFieldValue = caravanField(__instance);
             SyncedLaunch(__instance, destinationTile, arrivalAction, cafr, caravanFieldValue);
 
             return false;
@@ -81,7 +81,7 @@ namespace Multiplayer.Compat
         private static void SyncedLaunch(ThingComp compLaunchableSrts, int destinationTile, TransportPodsArrivalAction arrivalAction, Caravan caravanMethodParameter, Caravan caravanFieldValue)
         {
             isSyncing = true;
-            caravanField.SetValue(compLaunchableSrts, caravanFieldValue);
+            caravanField(compLaunchableSrts) = caravanFieldValue;
             tryLaunchMethod.Invoke(compLaunchableSrts, new object[] { destinationTile, arrivalAction, caravanMethodParameter });
         }
 

--- a/Source/Mods/SmartFarming.cs
+++ b/Source/Mods/SmartFarming.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections;
-using System.Reflection;
 using HarmonyLib;
 using Multiplayer.API;
 using Verse;
@@ -13,7 +12,7 @@ namespace Multiplayer.Compat
     internal class SmartFarming
     {
         private static IDictionary compCache;
-        private static FieldInfo growZoneRegistryField;
+        private static AccessTools.FieldRef<object, IDictionary> growZoneRegistryField;
 
         public SmartFarming(ModContentPack mod)
         {
@@ -21,7 +20,7 @@ namespace Multiplayer.Compat
             compCache = AccessTools.StaticFieldRefAccess<IDictionary>(type, "compCache");
 
             type = AccessTools.TypeByName("SmartFarming.MapComponent_SmartFarming");
-            growZoneRegistryField = AccessTools.Field(type, "growZoneRegistry");
+            growZoneRegistryField = AccessTools.FieldRefAccess<IDictionary>(type, "growZoneRegistry");
 
             type = AccessTools.TypeByName("SmartFarming.ZoneData");
             MpCompat.RegisterLambdaDelegate(type, "Init", 3, 4).SetContext(SyncContext.CurrentMap); // Toggle no petty jobs, force harvest now
@@ -36,7 +35,7 @@ namespace Multiplayer.Compat
             {
                 int? id = null;
                 var comp = compCache[Find.CurrentMap];
-                var zoneRegistry = (IDictionary)growZoneRegistryField.GetValue(comp);
+                var zoneRegistry = growZoneRegistryField(comp);
 
                 foreach (DictionaryEntry entry in zoneRegistry)
                 {
@@ -55,7 +54,7 @@ namespace Multiplayer.Compat
                 if (id != null)
                 {
                     var comp = compCache[Find.CurrentMap];
-                    var zoneRegistry = (IDictionary)growZoneRegistryField.GetValue(comp);
+                    var zoneRegistry = growZoneRegistryField(comp);
                     zoneData = zoneRegistry[id.Value];
                 }
             }

--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -21,36 +21,38 @@ namespace Multiplayer.Compat
     {
         // VFECore
         // CompAbility
-        private static FieldInfo learnedAbilitiesField;
+        private static Type compAbilitiesType;
+        private static AccessTools.FieldRef<object, IEnumerable> learnedAbilitiesField;
         // CompAbilityApparel
-        private static FieldInfo givenAbilitiesField;
+        private static Type compAbilitiesApparelType;
+        private static AccessTools.FieldRef<object, IEnumerable> givenAbilitiesField;
         private static MethodInfo abilityApparelPawnGetter;
         // Ability
         private static MethodInfo abilityInitMethod;
-        private static FieldInfo abilityHolderField;
-        private static FieldInfo abilityPawnField;
+        private static AccessTools.FieldRef<object, Thing> abilityHolderField;
+        private static AccessTools.FieldRef<object, Pawn> abilityPawnField;
         private static ISyncField abilityAutoCastField;
         // Dialog_Hire
         private static Type hireDialogType;
-        private static FieldInfo hireDataField;
+        private static AccessTools.FieldRef<object, Dictionary<PawnKindDef, Pair<int, string>>> hireDataField;
         private static ISyncField daysAmountField;
         private static ISyncField currentFactionDefField;
 
         // Vanilla Furniture Expanded
-        private static FieldInfo setStoneBuildingField;
+        private static AccessTools.FieldRef<object, ThingComp> setStoneBuildingField;
 
         // MVCF
         // VerbManager
         private static ConstructorInfo mvcfVerbManagerCtor;
         private static MethodInfo mvcfInitializeManagerMethod;
         private static MethodInfo mvcfPawnGetter;
-        private static FieldInfo mvcfVerbsField;
+        private static AccessTools.FieldRef<object, IList> mvcfVerbsField;
         // WorldComponent_MVCF
         private static MethodInfo mvcfGetWorldCompMethod;
-        private static FieldInfo mvcfAllManagersListField;
-        private static FieldInfo mvcfManagersTableField;
+        private static AccessTools.FieldRef<object, object> mvcfAllManagersListField;
+        private static AccessTools.FieldRef<object, object> mvcfManagersTableField;
         // ManagedVerb
-        private static FieldInfo mvcfManagerVerbManagerField;
+        private static AccessTools.FieldRef<object, object> mvcfManagerVerbManagerField;
 
         // System
         // WeakReference
@@ -94,22 +96,23 @@ namespace Multiplayer.Compat
             // VFE Core
             {
                 MpCompat.RegisterLambdaMethod("VFECore.CompPawnDependsOn", "CompGetGizmosExtra", 0).SetDebugOnly();
-                
+
                 // Comp holding ability
                 // CompAbility
-                learnedAbilitiesField = AccessTools.Field(AccessTools.TypeByName("VFECore.Abilities.CompAbilities"), "learnedAbilities");
+                compAbilitiesType = AccessTools.TypeByName("VFECore.Abilities.CompAbilities");
+                learnedAbilitiesField = AccessTools.FieldRefAccess<IEnumerable>(compAbilitiesType, "learnedAbilities");
                 // CompAbilityApparel
-                var type = AccessTools.TypeByName("VFECore.Abilities.CompAbilitiesApparel");
-                givenAbilitiesField = AccessTools.Field(type, "givenAbilities");
-                abilityApparelPawnGetter = AccessTools.PropertyGetter(type, "Pawn");
-                MP.RegisterSyncMethod(type, "Initialize");
-
+                compAbilitiesApparelType = AccessTools.TypeByName("VFECore.Abilities.CompAbilitiesApparel");
+                givenAbilitiesField = AccessTools.FieldRefAccess<IEnumerable>(compAbilitiesApparelType, "givenAbilities");
+                abilityApparelPawnGetter = AccessTools.PropertyGetter(compAbilitiesApparelType, "Pawn");
+                //MP.RegisterSyncMethod(compAbilitiesApparelType, "Initialize");
+                
                 // Ability itself
-                type = AccessTools.TypeByName("VFECore.Abilities.Ability");
+                var type = AccessTools.TypeByName("VFECore.Abilities.Ability");
 
                 abilityInitMethod = AccessTools.Method(type, "Init");
-                abilityHolderField = AccessTools.Field(type, "holder");
-                abilityPawnField = AccessTools.Field(type, "pawn");
+                abilityHolderField = AccessTools.FieldRefAccess<Thing>(type, "holder");
+                abilityPawnField = AccessTools.FieldRefAccess<Pawn>(type, "pawn");
                 MP.RegisterSyncMethod(type, "CreateCastJob");
                 MP.RegisterSyncWorker<ITargetingSource>(SyncVEFAbility, type, true);
                 abilityAutoCastField = MP.RegisterSyncField(type, "autoCast");
@@ -124,7 +127,7 @@ namespace Multiplayer.Compat
                 MP.RegisterSyncWorker<Window>(SyncHireDialog, hireDialogType);
                 MP.RegisterSyncMethod(typeof(VanillaExpandedFramework), nameof(SyncedSetHireData));
                 MP.RegisterSyncMethod(typeof(VanillaExpandedFramework), nameof(SyncedCloseHireDialog));
-                hireDataField = AccessTools.Field(hireDialogType, "hireData");
+                hireDataField = AccessTools.FieldRefAccess<Dictionary<PawnKindDef, Pair<int, string>>>(hireDialogType, "hireData");
                 // I don't think daysAmountBuffer needs to be synced, just daysAmount only
                 daysAmountField = MP.RegisterSyncField(hireDialogType, "daysAmount");
                 currentFactionDefField = MP.RegisterSyncField(hireDialogType, "curFaction");
@@ -144,7 +147,7 @@ namespace Multiplayer.Compat
                 MpCompat.RegisterLambdaMethod("VanillaFurnitureExpanded.CompRockSpawner", "CompGetGizmosExtra", 0);
 
                 type = AccessTools.TypeByName("VanillaFurnitureExpanded.Command_SetStoneType");
-                setStoneBuildingField = AccessTools.Field(type, "building");
+                setStoneBuildingField = AccessTools.FieldRefAccess<ThingComp>(type, "building");
                 MpCompat.RegisterLambdaMethod(type, "ProcessInput", 0);
                 MP.RegisterSyncWorker<Command>(SyncSetStoneTypeCommand, type, shouldConstruct: true);
                 MpCompat.RegisterLambdaDelegate(type, "ProcessInput", 1);
@@ -200,8 +203,8 @@ namespace Multiplayer.Compat
             {
                 var type = AccessTools.TypeByName("MVCF.WorldComponent_MVCF");
                 mvcfGetWorldCompMethod = AccessTools.Method(type, "GetComp");
-                mvcfAllManagersListField = AccessTools.Field(type, "allManagers");
-                mvcfManagersTableField = AccessTools.Field(type, "managers");
+                mvcfAllManagersListField = AccessTools.FieldRefAccess<object>(type, "allManagers");
+                mvcfManagersTableField = AccessTools.FieldRefAccess<object>(type, "managers");
                 MP.RegisterSyncMethod(typeof(VanillaExpandedFramework), nameof(SyncedInitVerbManager));
                 MpCompat.harmony.Patch(AccessTools.Method(type, "GetManagerFor"),
                     prefix: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(GetManagerForPrefix)));
@@ -211,17 +214,17 @@ namespace Multiplayer.Compat
                 mvcfVerbManagerCtor = AccessTools.Constructor(type);
                 mvcfInitializeManagerMethod = AccessTools.Method(type, "Initialize");
                 mvcfPawnGetter = AccessTools.PropertyGetter(type, "Pawn");
-                mvcfVerbsField = AccessTools.Field(type, "verbs");
+                mvcfVerbsField = AccessTools.FieldRefAccess<IList>(type, "verbs");
 
-                var weakReferenceType = typeof(System.WeakReference<>).MakeGenericType(new[] { type });
+                var weakReferenceType = typeof(System.WeakReference<>).MakeGenericType(type);
                 weakReferenceCtor = AccessTools.FirstConstructor(weakReferenceType, ctor => ctor.GetParameters().Count() == 1);
 
-                var conditionalWeakTableType = typeof(System.Runtime.CompilerServices.ConditionalWeakTable<,>).MakeGenericType(new[] { typeof(Pawn), type });
+                var conditionalWeakTableType = typeof(System.Runtime.CompilerServices.ConditionalWeakTable<,>).MakeGenericType(typeof(Pawn), type);
                 conditionalWeakTableAddMethod = AccessTools.Method(conditionalWeakTableType, "Add");
                 conditionalWeakTableTryGetValueMethod = AccessTools.Method(conditionalWeakTableType, "TryGetValue");
 
                 type = AccessTools.TypeByName("MVCF.ManagedVerb");
-                mvcfManagerVerbManagerField = AccessTools.Field(type, "man");
+                mvcfManagerVerbManagerField = AccessTools.FieldRefAccess<object>(type, "man");
                 MP.RegisterSyncWorker<object>(SyncManagedVerb, type, isImplicit: true);
                 // Seems like selecting the Thing that holds the verb inits some stuff, so we need to set the context
                 MP.RegisterSyncMethod(type, "Toggle");
@@ -304,9 +307,9 @@ namespace Multiplayer.Compat
         private static void SyncSetStoneTypeCommand(SyncWorker sync, ref Command obj)
         {
             if (sync.isWriting)
-                sync.Write(setStoneBuildingField.GetValue(obj) as ThingComp);
+                sync.Write(setStoneBuildingField(obj));
             else
-                setStoneBuildingField.SetValue(obj, sync.Read<ThingComp>());
+                setStoneBuildingField(obj) = sync.Read<ThingComp>();
         }
 
         private static void SyncVerbManager(SyncWorker sync, ref object obj)
@@ -319,7 +322,7 @@ namespace Multiplayer.Compat
                 var pawn = sync.Read<Pawn>();
 
                 var comp = mvcfGetWorldCompMethod.Invoke(null, Array.Empty<object>());
-                var weakTable = mvcfManagersTableField.GetValue(comp);
+                var weakTable = mvcfManagersTableField(comp);
 
                 var outParam = new object[] { pawn, null };
 
@@ -336,9 +339,9 @@ namespace Multiplayer.Compat
             if (sync.isWriting)
             {
                 // Get the VerbManager from inside of the ManagedVerb itself
-                var verbManager = mvcfManagerVerbManagerField.GetValue(obj);
+                var verbManager = mvcfManagerVerbManagerField(obj);
                 // Find the ManagedVerb inside of list of all verbs
-                var managedVerbsList = mvcfVerbsField.GetValue(verbManager) as IList;
+                var managedVerbsList = mvcfVerbsField(verbManager);
                 var index = managedVerbsList.IndexOf(obj);
 
                 // Sync the index of the verb as well as the manager (if it's valid)
@@ -358,7 +361,7 @@ namespace Multiplayer.Compat
                     SyncVerbManager(sync, ref verbManager);
 
                     // Find the ManagedVerb with specific index inside of list of all verbs
-                    var managedVerbsList = mvcfVerbsField.GetValue(verbManager) as IList;
+                    var managedVerbsList = mvcfVerbsField(verbManager);
                     obj = managedVerbsList[index];
                 }
             }
@@ -368,7 +371,7 @@ namespace Multiplayer.Compat
         {
             if (sync.isWriting)
             {
-                sync.Write(abilityHolderField.GetValue(source) as Thing);
+                sync.Write(abilityHolderField(source));
                 sync.Write(source.GetVerb.GetUniqueLoadID());
             }
             else
@@ -379,16 +382,16 @@ namespace Multiplayer.Compat
                 {
                     IEnumerable list = null;
 
-                    var compAbilities = thing.AllComps.FirstOrDefault(c => c.GetType() == learnedAbilitiesField.DeclaringType);
+                    var compAbilities = thing.AllComps.FirstOrDefault(c => c.GetType() == compAbilitiesType);
                     ThingComp compAbilitiesApparel = null;
                     if (compAbilities != null)
-                        list = learnedAbilitiesField.GetValue(compAbilities) as IEnumerable;
+                        list = learnedAbilitiesField(compAbilities);
 
                     if (list == null)
                     {
-                        compAbilitiesApparel = thing.AllComps.FirstOrDefault(c => c.GetType() == givenAbilitiesField.DeclaringType);
+                        compAbilitiesApparel = thing.AllComps.FirstOrDefault(c => c.GetType() == compAbilitiesApparelType);
                         if (compAbilitiesApparel != null)
-                            list = givenAbilitiesField.GetValue(compAbilitiesApparel) as IEnumerable;
+                            list = givenAbilitiesField(compAbilitiesApparel);
                     }
 
                     if (list != null)
@@ -406,8 +409,8 @@ namespace Multiplayer.Compat
                         if (source != null && compAbilitiesApparel != null)
                         {
                             // Set the pawn and initialize the Ability, as it might have been skipped
-                            var pawn = abilityApparelPawnGetter.Invoke(compAbilitiesApparel, Array.Empty<object>());
-                            abilityPawnField.SetValue(source, pawn);
+                            var pawn = abilityApparelPawnGetter.Invoke(compAbilitiesApparel, Array.Empty<object>()) as Pawn;
+                            abilityPawnField(source) = pawn;
                             abilityInitMethod.Invoke(source, Array.Empty<object>());
                         }
                     }
@@ -427,7 +430,7 @@ namespace Multiplayer.Compat
         {
             if (MP.IsInMultiplayer || !createIfMissing) return true; // We don't care and let the method run, we only care if we might need to creat a VerbManager
 
-            var table = mvcfManagersTableField.GetValue(__instance);
+            var table = mvcfManagersTableField(__instance);
             var parameters = new object[] { pawn, null };
 
             if ((bool)conditionalWeakTableTryGetValueMethod.Invoke(table, parameters))
@@ -458,7 +461,7 @@ namespace Multiplayer.Compat
         {
             if (comp == null) comp = (WorldComponent)mvcfGetWorldCompMethod.Invoke(null, Array.Empty<object>());
             if (comp == null) return null;
-            if (table == null) table = mvcfManagersTableField.GetValue(comp);
+            if (table == null) table = mvcfManagersTableField(comp);
             var parameters = new object[] { pawn, null };
             object verbManager;
 
@@ -485,11 +488,11 @@ namespace Multiplayer.Compat
         {
             var verbManager = mvcfVerbManagerCtor.Invoke(Array.Empty<object>());
 
-            if (list == null) list = mvcfAllManagersListField.GetValue(worldComponent);
-            if (table == null) table = mvcfManagersTableField.GetValue(worldComponent);
+            if (list == null) list = mvcfAllManagersListField(worldComponent);
+            if (table == null) table = mvcfManagersTableField(worldComponent);
 
-            conditionalWeakTableAddMethod.Invoke(table, new object[] { pawn, verbManager });
-            ((IList)list).Add(weakReferenceCtor.Invoke(new object[] { verbManager }));
+            conditionalWeakTableAddMethod.Invoke(table, new[] { pawn, verbManager });
+            ((IList)list).Add(weakReferenceCtor.Invoke(new[] { verbManager }));
 
             return verbManager;
         }
@@ -541,7 +544,7 @@ namespace Multiplayer.Compat
             {
                 if (value.First != ___hireData[pawn].First)
                 {
-                    hireDataField.SetValue(__instance, __state);
+                    hireDataField(__instance) = __state;
                     SyncedSetHireData(___hireData);
                     break;
                 }
@@ -556,7 +559,7 @@ namespace Multiplayer.Compat
             var dialog = Find.WindowStack.Windows.FirstOrDefault(x => x.GetType() == hireDialogType);
 
             if (dialog != null) 
-                hireDataField.SetValue(dialog, hireData);
+                hireDataField(dialog) = hireData;
         }
 
         private static void SyncedCloseHireDialog() 

--- a/Source/Mods/VanillaFactionsAncients.cs
+++ b/Source/Mods/VanillaFactionsAncients.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using HarmonyLib;
 using Multiplayer.API;
 using Verse;
@@ -12,7 +11,7 @@ namespace Multiplayer.Compat
     [MpCompatFor("VanillaExpanded.VFEA")]
     internal class VanillaFactionsAncients
     {
-        private static FieldInfo operationPodField;
+        private static AccessTools.FieldRef<object, ThingComp> operationPodField;
 
         public VanillaFactionsAncients(ModContentPack mod)
         {
@@ -22,7 +21,7 @@ namespace Multiplayer.Compat
             // VFEAncients.CompGeneTailoringPod:StartOperation requires SyncWorker for Operation
             // (Method inside of LatePatch)
             var type = AccessTools.TypeByName("VFEAncients.Operation");
-            operationPodField = AccessTools.Field(type, "Pod");
+            operationPodField = AccessTools.FieldRefAccess<ThingComp>(type, "Pod");
             MP.RegisterSyncWorker<object>(SyncOperation, type, true);
 
             LongEventHandler.ExecuteWhenFinished(LatePatch);
@@ -50,7 +49,7 @@ namespace Multiplayer.Compat
         {
             if (sync.isWriting)
             {
-                sync.Write((ThingComp)operationPodField.GetValue(operation));
+                sync.Write(operationPodField(operation));
                 // Right now we have 2 types it could be, but there could be more in the future
                 sync.Write(operation.GetType());
             }

--- a/Source/Mods/VanillaFurnitureExpandedPower.cs
+++ b/Source/Mods/VanillaFurnitureExpandedPower.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reflection;
 using HarmonyLib;
 using Multiplayer.API;
 using UnityEngine;
@@ -14,7 +13,7 @@ namespace Multiplayer.Compat
     [MpCompatFor("VanillaExpanded.VFEPower")]
     class VanillaPowerExpanded
     {
-        private static FieldInfo windDirectionField;
+        private static AccessTools.FieldRef<object, float> windDirectionField;
 
         public VanillaPowerExpanded(ModContentPack mod)
         {
@@ -79,7 +78,7 @@ namespace Multiplayer.Compat
                 LongEventHandler.ExecuteWhenFinished(() => PatchingUtilities.PatchPushPopRand(methodsForLater));
 
                 // Wind map comp
-                windDirectionField = AccessTools.Field(AccessTools.TypeByName("GasNetwork.MapComponent_WindDirection"), "windDirection");
+                windDirectionField = AccessTools.FieldRefAccess<float>(AccessTools.TypeByName("GasNetwork.MapComponent_WindDirection"), "windDirection");
                 
                 PatchingUtilities.PatchUnityRand("GasNetwork.MapComponent_WindDirection:MapGenerated");
                 MpCompat.harmony.Patch(AccessTools.Method("GasNetwork.MapComponent_WindDirection:MapComponentTick"),
@@ -104,7 +103,7 @@ namespace Multiplayer.Compat
             {
                 const float twoPI = Mathf.PI * 2;
                 // Use Verse rand instead of Unity
-                windDirectionField.SetValue(__instance, ((float)windDirectionField.GetValue(__instance) + Rand.Range(-0.3f, 0.3f)) % twoPI);
+                windDirectionField(__instance) = (windDirectionField(__instance) + Rand.Range(-0.3f, 0.3f)) % twoPI;
             }
 
             return false;


### PR DESCRIPTION
Additionally, updated Choice Of Psycasts and Path Avoid (as I noticed they weren't up to date while working on them).

Using FieldRefAccess is more convienient than using FieldInfo, as well as it's significantly more performant. It might be negligible in most of those cases as they're very rarely used - although there's no point in not doing it either. Unfortunately, I don't think we can do similar to MethodInfo, unless we reference the .dll and call the methods directly.

Relies on #143 for a couple of small changes to Vanilla Furniture Expanded - Security.