### PR TITLE
Call DefDatabase<BuildableDef>.Add() directly

### DIFF
--- a/Source/Mods/ClutterStructures.cs
+++ b/Source/Mods/ClutterStructures.cs
@@ -11,8 +11,6 @@ namespace Multiplayer.Compat
     {
         public ClutterStructures(ModContentPack mod)
         {
-            StuffedFloorsCompat.Init();
-
             MpCompat.harmony.Patch(
                 AccessTools.Method("Clutter_StructureWall.StructureDefGenerator:StuffGeneratrs"),
                 postfix: new HarmonyMethod(typeof(ClutterStructures), nameof(GetClutterStructureDefPostfix))
@@ -21,7 +19,7 @@ namespace Multiplayer.Compat
 
         static void GetClutterStructureDefPostfix(ThingDef Wallzie)
         {
-            StuffedFloorsCompat.defDatabaseAddMethod.Invoke(null, new object[] { Wallzie });
+            DefDatabase<BuildableDef>.Add(Wallzie);
         }
     }
 }

--- a/Source/Mods/SimplyMoreBridges.cs
+++ b/Source/Mods/SimplyMoreBridges.cs
@@ -11,14 +11,8 @@ namespace Multiplayer.Compat
     [MpCompatFor("Mlie.SimplyMoreBridges")]
     class SimplyMoreBridgesCompat
     {
-        static MethodInfo defDatabaseAddMethod;
-
         public SimplyMoreBridgesCompat(ModContentPack mod)
         {
-            Type[] generic = { typeof(BuildableDef) };
-
-            defDatabaseAddMethod = AccessTools.Method(typeof(DefDatabase<>).MakeGenericType(generic), "Add", generic);
-
             MpCompat.harmony.Patch(
                 AccessTools.Method("SimplyMoreBridges.GenerateBridges:GenerateBridgeDef"),
                 postfix: new HarmonyMethod(typeof(SimplyMoreBridgesCompat), nameof(GenerateBridgeDefPostfix))
@@ -27,7 +21,7 @@ namespace Multiplayer.Compat
 
         static void GenerateBridgeDefPostfix(TerrainDef __result)
         {
-            defDatabaseAddMethod.Invoke(null, new object[] { __result });
+            DefDatabase<BuildableDef>.Add(__result);
         }
     }
 }

--- a/Source/Mods/StuffedFloors.cs
+++ b/Source/Mods/StuffedFloors.cs
@@ -12,31 +12,17 @@ namespace Multiplayer.Compat
     [MpCompatFor("fluffy.stuffedfloors")]
     class StuffedFloorsCompat
     {
-        internal static MethodInfo defDatabaseAddMethod;
-
         public StuffedFloorsCompat(ModContentPack mod)
         {
-            Init();
-
             MpCompat.harmony.Patch(
                 AccessTools.Method("StuffedFloors.FloorTypeDef:GetStuffedTerrainDef"),
                 postfix: new HarmonyMethod(typeof(StuffedFloorsCompat), nameof(GetStuffedTerrainDefPosfix))
                 );
         }
 
-        internal static void Init()
-        {
-            if (defDatabaseAddMethod == null)
-            {
-                Type[] generic = { typeof(BuildableDef) };
-
-                defDatabaseAddMethod = AccessTools.Method(typeof(DefDatabase<>).MakeGenericType(generic), "Add", generic);
-            }
-        }
-
         static void GetStuffedTerrainDefPosfix(TerrainDef __result)
         {
-            defDatabaseAddMethod.Invoke(null, new object[] { __result });
+            DefDatabase<BuildableDef>.Add(__result);
         }
     }
 }


### PR DESCRIPTION
Right now we were using reflection to do this. The method itself is public. Was there a reason we used to do it like this?