### PR TITLE
Added compat for Smart Speed

### DIFF
--- a/Source/Mods/SmartSpeed.cs
+++ b/Source/Mods/SmartSpeed.cs
@@ -1,0 +1,43 @@
+﻿using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Smart Speed by Sarg</summary>
+    /// <see href="https://github.com/juanosarg/Smart-Speed"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1504723424"/>
+    [MpCompatFor("sarg.smartspeed")]
+    internal class SmartSpeed
+    {
+        public SmartSpeed(ModContentPack mod) 
+            => LongEventHandler.ExecuteWhenFinished(LatePatch);
+
+        private static void LatePatch()
+        {
+            var type = AccessTools.TypeByName("Multiplayer.Client.AsyncTime.TimeControlsMarker");
+            var drawingTimeControlsPrefix = AccessTools.Method(type, "Prefix");
+            var drawingTimeControlsPostfix = AccessTools.Method(type, "Postfix");
+
+            type = AccessTools.TypeByName("Multiplayer.Client.AsyncTime.TimeControlPatch");
+            var doTimeControlPrefix = AccessTools.Method(type, "Prefix");
+            var doTimeControlPostfix = AccessTools.Method(type, "Postfix");
+
+            type = AccessTools.TypeByName("SmartSpeed.Detouring.TimeControls");
+            var method = AccessTools.Method(type, "DoTimeControlsGUI");
+            MpCompat.harmony.Patch(method,
+                prefix: new HarmonyMethod(drawingTimeControlsPrefix),
+                postfix: new HarmonyMethod(drawingTimeControlsPostfix));
+            MpCompat.harmony.Patch(method,
+                prefix: new HarmonyMethod(doTimeControlPrefix),
+                postfix: new HarmonyMethod(doTimeControlPostfix));
+
+            // Cancel the menu for changing speed multiplier in events,
+            // as we're not supporting it (at least for now)
+            MpCompat.harmony.Patch(AccessTools.Method(type, "DoConfigGUI"),
+                prefix: new HarmonyMethod(typeof(SmartSpeed), nameof(CancelInMp)));
+        }
+
+        private static bool CancelInMp() => !MP.IsInMultiplayer;
+    }
+}


### PR DESCRIPTION
Most of the features work - ultraspeed without dev mode, and ultraspeed icon.

However, speed multiplier in events is not supported, as it would most likely require doing Harmony patches on Multiplayer. While in multiplayer, the menu for setting those options is disabled, since it wouldn't do anything anyway.