### PR TITLE
Change extensions for ISyncDelegate/Method arrays to work on IEnumerables

### DIFF
--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Multiplayer.API;
 
 namespace Multiplayer.Compat
@@ -28,7 +29,7 @@ namespace Multiplayer.Compat
             return num;
         }
 
-        public static void SetDebugOnly(this ISyncMethod[] syncMethods)
+        public static void SetDebugOnly(this IEnumerable<ISyncMethod> syncMethods)
         {
             foreach (var method in syncMethods)
             {
@@ -36,7 +37,7 @@ namespace Multiplayer.Compat
             }
         }
 
-        public static void SetDebugOnly(this ISyncDelegate[] syncMethods)
+        public static void SetDebugOnly(this IEnumerable<ISyncDelegate> syncMethods)
         {
             foreach (var method in syncMethods)
             {
@@ -44,7 +45,7 @@ namespace Multiplayer.Compat
             }
         }
 
-        public static void SetContext(this ISyncMethod[] syncDelegates, SyncContext context)
+        public static void SetContext(this IEnumerable<ISyncMethod> syncDelegates, SyncContext context)
         {
             foreach (var method in syncDelegates)
             {
@@ -52,7 +53,7 @@ namespace Multiplayer.Compat
             }
         }
 
-        public static void SetContext(this ISyncDelegate[] syncDelegates, SyncContext context)
+        public static void SetContext(this IEnumerable<ISyncDelegate> syncDelegates, SyncContext context)
         {
             foreach (var method in syncDelegates)
             {

--- a/Source/Mods/AnimaObelisk.cs
+++ b/Source/Mods/AnimaObelisk.cs
@@ -14,7 +14,7 @@ namespace Multiplayer.Compat
             var type = AccessTools.TypeByName("PsyObelisk.Things.ThingComp_PsyObelisk");
             PatchingUtilities.PatchUnityRand(AccessTools.Method(type, "GlowAround"), false);
             var syncMethods = MpCompat.RegisterLambdaMethod(type, "CompGetGizmosExtra", Enumerable.Range(0, 8).ToArray()); // 0 to 7
-            syncMethods.Skip(2).ToArray().SetDebugOnly();
+            syncMethods.Skip(2).SetDebugOnly();
         }
     }
 }


### PR DESCRIPTION
My main reason behind this is when working on the arrays, you sometimes want to do some LINQ operation, there'll no longer be need to turn that result into an array.