### PR TITLE
Fix patches for new Harmony mod version

### DIFF
--- a/Source/Mods/AlphaAnimals.cs
+++ b/Source/Mods/AlphaAnimals.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using HarmonyLib;
+using Verse;
 
 namespace Multiplayer.Compat
 {
@@ -30,10 +31,13 @@ namespace Multiplayer.Compat
                     "AlphaBehavioursAndEvents.Hediff_Crushing:RandomFilthGenerator",
 
                     // Ocular plant conversion
-                    "AlphaBehavioursAndEvents.CompAbilityOcularConversion:Apply",
                     "AlphaBehavioursAndEvents.Gas_Ocular:Tick",
                 };
                 PatchingUtilities.PatchPushPopRand(rngFixMethods);
+
+                // Patch separately to avoid "Ambiguous match in Harmony patch"
+                var compAbilityOcularConversionApply = AccessTools.Method("AlphaBehavioursAndEvents.CompAbilityOcularConversion:Apply", new System.Type[] { typeof(LocalTargetInfo), typeof(LocalTargetInfo) });
+                PatchingUtilities.PatchPushPopRand(compAbilityOcularConversionApply);
             }
         }
     }

--- a/Source/Mods/VanillaIdeologyMemes.cs
+++ b/Source/Mods/VanillaIdeologyMemes.cs
@@ -18,15 +18,17 @@ namespace Multiplayer.Compat
                 {
                     // Commented out the ones that use seeded random, as they should be fine
                     // If not, then uncommenting those lines should fix it
-                    "VanillaMemesExpanded.CompAbilityHarvestBodyParts:Apply",
                     //"VanillaMemesExpanded.VanillaMemesExpanded_GameConditionManager_RegisterCondition_Patch:SendRandomMood",
                     //"VanillaMemesExpanded.VanillaMemesExpanded_GameCondition_Aurora_Init_Patch:SendRandomMood",
                     //"VanillaMemesExpanded.RitualOutcomeEffectWorker_DivineStars:Apply",
                     "VanillaMemesExpanded.RitualOutcomeEffectWorker_SlaveEmancipation:Apply",
                     "VanillaMemesExpanded.RitualOutcomeEffectWorker_ViolentConversion:Apply",
                 };
-
                 PatchingUtilities.PatchSystemRand(methods, false);
+
+                // Patch separately to avoid "Ambiguous match in Harmony patch"
+                var compAbilityHarvestBodyPartsApply = AccessTools.Method("VanillaMemesExpanded.CompAbilityHarvestBodyParts:Apply", new System.Type[] { typeof(LocalTargetInfo), typeof(LocalTargetInfo) });
+                PatchingUtilities.PatchPushPopRand(compAbilityHarvestBodyPartsApply);
             }
 
             // Gizmos


### PR DESCRIPTION
With Harmony mod update from 18.04.2022 some patches began to throw "Ambiguous match in Harmony patch" exception, this commit fixes it