### PR TITLE
Slightly changed how loading .dll for referenced mods works

### DIFF
--- a/Source/MpCompatLoader.cs
+++ b/Source/MpCompatLoader.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using HarmonyLib;
 using Mono.Cecil;
 using Verse;
 
@@ -33,12 +35,18 @@ namespace Multiplayer.Compat
             foreach (var t in asm.MainModule.GetTypes().ToArray())
             {
                 var attr = t.CustomAttributes
-                    .FirstOrDefault(a => a.Constructor.DeclaringType.Name == nameof(MpCompatForAttribute));
-                if (attr == null) continue;
+                    .Where(a => a.Constructor.DeclaringType.Name is nameof(MpCompatForAttribute) or nameof(MpCompatRequireModAttribute))
+                    .ToArray();
+                if (!attr.Any()) continue;
 
-                var modId = ((string)attr.ConstructorArguments.First().Value).ToLower();
-                var mod = LoadedModManager.RunningMods.FirstOrDefault(m => m.PackageId.NoModIdSuffix() == modId);
-                if (mod == null)
+                var anyMod = attr.Any(a =>
+                {
+                    var modId = ((string)a.ConstructorArguments.First().Value).ToLower();
+                    var mod = LoadedModManager.RunningMods.FirstOrDefault(m => m.PackageId.NoModIdSuffix() == modId);
+                    return mod != null;
+                });
+                
+                if (!anyMod)
                     asm.MainModule.Types.Remove(t);
             }
 
@@ -46,7 +54,14 @@ namespace Multiplayer.Compat
             asm.Write(stream);
 
             var loadedAsm = AppDomain.CurrentDomain.Load(stream.ToArray());
-            InitCompatInAsm(loadedAsm);
+            content.assemblies.loadedAssemblies.Add(loadedAsm);
+            // As we're adding the new assembly, the classes added by it aren't included by the MP GenTypes AllSubclasses/AllSubclassesNonAbstract optimization
+            // GenTypes.ClearCache() won't work, as MP isn't doing anything when it's called
+            var mpType = AccessTools.TypeByName("Multiplayer.Client.Multiplayer");
+            ((IDictionary)AccessTools.Field(mpType, "subClasses").GetValue(null)).Clear();
+            ((IDictionary)AccessTools.Field(mpType, "subClassesNonAbstract").GetValue(null)).Clear();
+            ((IDictionary)AccessTools.Field(mpType, "implementations").GetValue(null)).Clear();
+            AccessTools.Method(mpType, "CacheTypeHierarchy").Invoke(null, Array.Empty<object>());
         }
 
         static void InitCompatInAsm(Assembly asm)

--- a/Source/MpCompatRequireModAttribute.cs
+++ b/Source/MpCompatRequireModAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Multiplayer.Compat
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class MpCompatRequireModAttribute : Attribute
+    {
+        public string PackageId { get; }
+
+        public MpCompatRequireModAttribute(string packageId) => PackageId = packageId;
+
+        public override object TypeId => this;
+    }
+}


### PR DESCRIPTION
- Added MpCompatRequireModAttribute, which works similar to MpCompatForAttribute in that it'll be removed from loaded assembly if the mod is not active. The main difference is that it won't be loaded as a compat to the mod.
- MpCompatLoader looks for all MpCompatForAttribute and MpCompatRequireModAttribute attributes (instead of a single one)
- It'll check for each mod referenced by those attributes. If none are found, it'll remove the type from assembly.
- The assembly is added to loaded assemblies. Removed the call to InitCompatInAsm, as it's no longer needed because of that change.
- Cleared all types from Multiplayer cache for GenTypes and regenerated it again. It's needed as GenTypes AllSubclasses/AllSubclassesNonAbstract would not be able to find classes from referenced .dll file. Needed to make the create GameComponents, and similar stuff, that we define in referenced .dll.