### PR TITLE
Sync camera-dependent stuff like VFE-Medieval archery range. Fix VFE-Pirates error.

### DIFF
--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -76,7 +76,7 @@ namespace Multiplayer.Compat
             (Action patchMethod, string componentName, bool latePatch)[] patches =
             {
                 (PatchItemProcessor, "Item Processor", false),
-                (PatchVanillaCookingExpanded, "Vanilla Cooking Expanded", false),
+                (PatchOtherRng, "Other RNG", false),
                 (PatchVFECoreDebug, "Debug Gizmos", false),
                 (PatchAbilities, "Abilities", false),
                 (PatchHireableFactions, "Hireable Factions", false),
@@ -133,10 +133,19 @@ namespace Multiplayer.Compat
             }
         }
 
-        private static void PatchVanillaCookingExpanded()
+        private static void PatchOtherRng()
         {
-            // AddHediff desyncs with Arbiter, but seems fine without it
-            PatchingUtilities.PatchPushPopRand("VanillaCookingExpanded.Thought_Hediff:MoodOffset");
+            PatchingUtilities.PatchPushPopRand(new[]
+            {
+                // AddHediff desyncs with Arbiter, but seems fine without it
+                "VanillaCookingExpanded.Thought_Hediff:MoodOffset",
+                // Uses GenView.ShouldSpawnMotesAt and uses RNG if it returns true,
+                // and it's based on player camera position. Need to push/pop or it'll desync
+                // unless all players looking when it's called
+                "VFECore.HediffComp_Spreadable:ThrowFleck",
+                // GenView.ShouldSpawnMotesAt again
+                "VFECore.TerrainComp_MoteSpawner:ThrowMote",
+            });
         }
 
         private static void PatchVFECoreDebug()

--- a/Source/Mods/VanillaFactionsMedieval.cs
+++ b/Source/Mods/VanillaFactionsMedieval.cs
@@ -1,0 +1,15 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Vanilla Traits Expanded by Oskar Potocki, XeoNovaDan</summary>
+    /// <see href="https://github.com/AndroidQuazar/VanillaFactionsExpandedMedieval"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2023513450"/>
+    [MpCompatFor("OskarPotocki.VanillaFactionsExpanded.MedievalModule")]
+    public class VanillaFactionsMedieval
+    {
+        // Archery target uses RNG - but only when the player is looking at it. Which may not be the case in MP for all players.
+        public VanillaFactionsMedieval(ModContentPack mod)
+            => PatchingUtilities.PatchPushPopRand("VFEMedieval.JobDriver_PlayArchery:ThrowObjectAt");
+    }
+}

--- a/Source/Mods/VanillaFactionsPirates.cs
+++ b/Source/Mods/VanillaFactionsPirates.cs
@@ -102,6 +102,12 @@ namespace Multiplayer.Compat
                 curseWorkerDisactivateMethod = AccessTools.Method(type, "Disactivate");
                 curseWorkerStartMethod = AccessTools.Method(type, "Start");
             }
+            
+            // Flecks
+            {
+                // Uses GenView.ShouldSpawnMotesAt, which is based on camera position
+                PatchingUtilities.PatchPushPopRand("VFEPirates.IncomingSmoker:ThrowBlackSmoke");
+            }
         }
 
         private static void PreDoWindowContents(Window __instance, ref Color[] __state)

--- a/Source/Mods/VanillaFactionsPirates.cs
+++ b/Source/Mods/VanillaFactionsPirates.cs
@@ -45,8 +45,6 @@ namespace Multiplayer.Compat
             {
                 // Enable/disable siege mode
                 MpCompat.RegisterLambdaMethod("VFEPirates.Ability_SiegeMode", "GetGizmo", 0, 2);
-                // Trigger flight towards tile (right now, the TransportPodsArrivalAction parameter is always null)
-                MP.RegisterSyncMethod(AccessTools.TypeByName("VFEPirates.Ability_BlastOff"), "TryLaunch").ExposeParameter(1);
             }
 
             // Warcasket dialog


### PR DESCRIPTION
Fixes VFE-Medieval archery range. It was spawning motes only if seen by player, and it may not be the case for all players in MP.