### PR TITLE
Updated existing RNG patches, slightly improved PatchingUtilities

### DIFF
--- a/Source/Mods/AlphaBiomes.cs
+++ b/Source/Mods/AlphaBiomes.cs
@@ -26,10 +26,17 @@ namespace Multiplayer.Compat
             {
                 "AlphaBiomes.CompGasProducer:CompTick",
                 "AlphaBiomes.TarSprayer:SteamSprayerTick",
+                // AlphaBiomes.TarSprayer:ThrowAirPuffUp - only contained by above method
                 "AlphaBiomes.GameCondition_AcidRain:DoCellSteadyEffects",
             };
 
-            PatchingUtilities.PatchSystemRand(AccessTools.Constructor(AccessTools.TypeByName("AlphaBiomes.CompGasProducer")), false);
+            var systemRngFixConstructor = new[]
+            {
+                "AlphaBiomes.CompGasProducer",
+                "AlphaBiomes.HediffComp_GangreneWounds",
+            }.Select(x => AccessTools.DeclaredConstructor(AccessTools.TypeByName(x)));
+
+            PatchingUtilities.PatchSystemRand(systemRngFixConstructor, false);
             PatchingUtilities.PatchPushPopRand(rngFixMethods);
         }
 

--- a/Source/Mods/VanillaEventsExpanded.cs
+++ b/Source/Mods/VanillaEventsExpanded.cs
@@ -14,15 +14,6 @@ namespace Multiplayer.Compat
             {
                 "VEE.HeddifComp_MightJoin:CompPostTick",
 
-                "VEE.HuntingParty:TryExecuteWorker",
-                
-                // These 4 methods initialize System.Random, but don't use them in any way whatsoever.
-                //"VEE.PurpleEvents.GlobalWarming:ChangeBiomes",
-                //"VEE.PurpleEvents.GlobalWarming:ChangeTileTemp",
-                //"VEE.PurpleEvents.IceAge:ChangeBiomes",
-                //"VEE.PurpleEvents.IceAge:ChangeTileTemp",
-                "VEE.PurpleEvents.PsychicBloom:Init",
-
                 "VEE.RegularEvents.ApparelPod:TryExecuteWorker",
                 "VEE.RegularEvents.CaravanAnimalWI:GenerateGroup",
                 "VEE.RegularEvents.MeteoriteShower:TryExecuteWorker",

--- a/Source/Mods/VanillaFurnitureExpanded.cs
+++ b/Source/Mods/VanillaFurnitureExpanded.cs
@@ -19,6 +19,8 @@ namespace Multiplayer.Compat
             };
 
             PatchingUtilities.PatchSystemRand(methods, false);
+            // Uses ShouldSpawnMotesAt, so could potentially cause issues somewhere. Seems like no RNG though... Let's better be safe here.
+            PatchingUtilities.PatchPushPopRand("AOMoreFurniture.JobDriver_PlayDarts:ThrowDart");
         }
     }
 }

--- a/Source/Mods/VanillaStorytellersWinstonWaves.cs
+++ b/Source/Mods/VanillaStorytellersWinstonWaves.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using Multiplayer.API;
@@ -22,7 +23,7 @@ namespace Multiplayer.Compat
         {
             // RNG
             {
-                PatchingUtilities.PatchSystemRandCtor("VSEWW.Window_ChooseReward", false);
+                PatchingUtilities.PatchSystemRand("VSEWW.Window_ChooseReward:DoWindowContents", false);
             }
 
             // Dialogs

--- a/Source/PatchingUtilities.cs
+++ b/Source/PatchingUtilities.cs
@@ -15,7 +15,7 @@ namespace Multiplayer.Compat
         /// <summary>Patches out <see cref="System.Random"/> calls using <see cref="FixRNG(IEnumerable{CodeInstruction})"/>, and optionally surrounds the method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>.</summary>
         /// <param name="methods">Methods that needs patching</param>
         /// <param name="patchPushPop">Determines if the methods should be surrounded with push/pop calls</param>
-        public static void PatchSystemRand(string[] methods, bool patchPushPop = true)
+        public static void PatchSystemRand(IEnumerable<string> methods, bool patchPushPop = true)
         {
             foreach (var method in methods)
                 PatchSystemRand(AccessTools.DeclaredMethod(method) ?? AccessTools.Method(method), patchPushPop);
@@ -24,20 +24,20 @@ namespace Multiplayer.Compat
         /// <summary>Patches out <see cref="System.Random"/> calls using <see cref="FixRNG(IEnumerable{CodeInstruction})"/>, and optionally surrounds the method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>.</summary>
         /// <param name="methods">Methods that needs patching</param>
         /// <param name="patchPushPop">Determines if the methods should be surrounded with push/pop calls</param>
-        public static void PatchSystemRand(MethodBase[] methods, bool patchPushPop = true)
+        public static void PatchSystemRand(IEnumerable<MethodBase> methods, bool patchPushPop = true)
         {
             foreach (var method in methods)
                 PatchSystemRand(method, patchPushPop);
         }
 
         /// <summary>Patches out <see cref="System.Random"/> calls using <see cref="FixRNG(IEnumerable{CodeInstruction})"/>, and optionally surrounds the method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>.</summary>
-        /// <param name="methods">Methods that needs patching</param>
+        /// <param name="method">Methods that needs patching</param>
         /// <param name="patchPushPop">Determines if the methods should be surrounded with push/pop calls</param>
         public static void PatchSystemRand(string method, bool patchPushPop = true)
             => PatchSystemRand(AccessTools.DeclaredMethod(method) ?? AccessTools.Method(method), patchPushPop);
 
         /// <summary>Patches out <see cref="System.Random"/> calls using <see cref="FixRNG(IEnumerable{CodeInstruction})"/>, and optionally surrounds the method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>.</summary>
-        /// <param name="methods">Method that needs patching</param>
+        /// <param name="method">Method that needs patching</param>
         /// <param name="patchPushPop">Determines if the method should be surrounded with push/pop calls</param>
         public static void PatchSystemRand(MethodBase method, bool patchPushPop = true)
         {
@@ -50,24 +50,30 @@ namespace Multiplayer.Compat
         }
 
         /// <summary>Patches out <see cref="System.Random"/> calls using <see cref="FixRNG(IEnumerable{CodeInstruction})"/>, and optionally surrounds the method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>.</summary>
-        /// <param name="type">Type with a constructor that needs patching</param>
+        /// <param name="typeName">Type with a parameterless constructor that needs patching</param>
         /// <param name="patchPushPop">Determines if the method should be surrounded with push/pop calls</param>
-        public static void PatchSystemRandCtor(string type, bool patchPushPop = true)
-            => PatchSystemRand(AccessTools.Constructor(AccessTools.TypeByName(type)), patchPushPop);
+        public static void PatchSystemRandCtor(string typeName, bool patchPushPop = true)
+        {
+            var type = AccessTools.TypeByName(typeName);
+            PatchSystemRand(AccessTools.DeclaredConstructor(type) ?? AccessTools.Constructor(type), patchPushPop);
+        }
 
         /// <summary>Patches out <see cref="System.Random"/> calls using <see cref="FixRNG(IEnumerable{CodeInstruction})"/>, and optionally surrounds the method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>.</summary>
-        /// <param name="type">Type with a constructors that needs patching</param>
+        /// <param name="typeNames">Type with a parameterless constructors that needs patching</param>
         /// <param name="patchPushPop">Determines if the methods should be surrounded with push/pop calls</param>
-        public static void PatchSystemRandCtor(string[] types, bool patchPushPop = true)
+        public static void PatchSystemRandCtor(IEnumerable<string> typeNames, bool patchPushPop = true)
         {
-            foreach (var method in types)
-                PatchSystemRand(AccessTools.Constructor(AccessTools.TypeByName(method)), patchPushPop);
+            foreach (var typeName in typeNames)
+            {
+                var type = AccessTools.TypeByName(typeName);
+                PatchSystemRand(AccessTools.DeclaredConstructor(type) ?? AccessTools.Constructor(type), patchPushPop);
+            }
         }
 
         /// <summary>Surrounds method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>, as well as applies the transpiler (if provided).</summary>
         /// <param name="methods">Methods that needs patching (as string)</param>
         /// <param name="transpiler">Transpiler that will be applied to the method</param>
-        public static void PatchPushPopRand(string[] methods, HarmonyMethod transpiler = null)
+        public static void PatchPushPopRand(IEnumerable<string> methods, HarmonyMethod transpiler = null)
         {
             foreach (var method in methods)
                 PatchPushPopRand(AccessTools.DeclaredMethod(method) ?? AccessTools.Method(method), transpiler);
@@ -76,7 +82,7 @@ namespace Multiplayer.Compat
         /// <summary>Surrounds method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>, as well as applies the transpiler (if provided).</summary>
         /// <param name="methods">Method that needs patching</param>
         /// <param name="transpiler">Transpiler that will be applied to the method</param>
-        public static void PatchPushPopRand(MethodBase[] methods, HarmonyMethod transpiler = null)
+        public static void PatchPushPopRand(IEnumerable<MethodBase> methods, HarmonyMethod transpiler = null)
         {
             foreach (var method in methods)
                 PatchPushPopRand(method, transpiler);
@@ -103,7 +109,7 @@ namespace Multiplayer.Compat
         /// <summary>Patches out <see cref="UnityEngine.Random"/> calls using <see cref="FixUnityRNG(IEnumerable{CodeInstruction})"/>, and optionally surrounds the method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>.</summary>
         /// <param name="methods">Methods that needs patching</param>
         /// <param name="patchPushPop">Determines if the methods should be surrounded with push/pop calls</param>
-        public static void PatchUnityRand(string[] methods, bool patchPushPop = true)
+        public static void PatchUnityRand(IEnumerable<string> methods, bool patchPushPop = true)
         {
             foreach (var method in methods)
                 PatchUnityRand(AccessTools.DeclaredMethod(method) ?? AccessTools.Method(method), patchPushPop);
@@ -112,7 +118,7 @@ namespace Multiplayer.Compat
         /// <summary>Patches out <see cref="UnityEngine.Random"/> calls using <see cref="FixUnityRNG(IEnumerable{CodeInstruction})"/>, and optionally surrounds the method with <see cref="Rand.PushState"/> and <see cref="Rand.PopState"/>.</summary>
         /// <param name="methods">Methods that needs patching</param>
         /// <param name="patchPushPop">Determines if the methods should be surrounded with push/pop calls</param>
-        public static void PatchUnityRand(MethodBase[] methods, bool patchPushPop = true)
+        public static void PatchUnityRand(IEnumerable<MethodBase> methods, bool patchPushPop = true)
         {
             foreach (var method in methods)
                 PatchUnityRand(method, patchPushPop);
@@ -144,20 +150,30 @@ namespace Multiplayer.Compat
         private static readonly ConstructorInfo RandRedirectorSeededConstructor = typeof(RandRedirector).GetConstructor(new[] { typeof(int) });
 
         /// <summary>Transpiler that replaces all calls to <see cref="System.Random"/> constructor with calls to <see cref="RandRedirector"/> constructor</summary>
-        internal static IEnumerable<CodeInstruction> FixRNG(IEnumerable<CodeInstruction> instr)
+        internal static IEnumerable<CodeInstruction> FixRNG(IEnumerable<CodeInstruction> instr, MethodBase original)
         {
+            var anythingPatched = false;
+            
             foreach (var ci in instr)
             {
                 if (ci.opcode == OpCodes.Newobj && ci.operand is ConstructorInfo constructorInfo)
                 {
                     if (constructorInfo == SystemRandConstructor)
+                    {
                         ci.operand = RandRedirectorConstructor;
+                        anythingPatched = true;
+                    }
                     else if (constructorInfo == SystemRandSeededConstructor)
+                    {
                         ci.operand = RandRedirectorSeededConstructor;
+                        anythingPatched = true;
+                    }
                 }
 
                 yield return ci;
             }
+
+            if (!anythingPatched) Log.Warning($"No System RNG was patched for method: {original?.FullDescription() ?? "(unknown method)"}");
         }
 
         /// <summary>This class allows replacing any <see cref="System.Random"/> calls with <see cref="Verse.Rand"/> calls</summary>
@@ -201,24 +217,40 @@ namespace Multiplayer.Compat
         private static readonly MethodInfo VerseRandomValue = AccessTools.PropertyGetter(typeof(Rand), nameof(Rand.Value));
         private static readonly MethodInfo VerseInsideUnitCircle = AccessTools.PropertyGetter(typeof(Rand), nameof(Rand.InsideUnitCircle));
 
-        internal static IEnumerable<CodeInstruction> FixUnityRNG(IEnumerable<CodeInstruction> instr)
+        internal static IEnumerable<CodeInstruction> FixUnityRNG(IEnumerable<CodeInstruction> instr, MethodBase original)
         {
+            var anythingPatched = false;
+            
             foreach (var ci in instr)
             {
                 if (ci.opcode == OpCodes.Call && ci.operand is MethodInfo method)
                 {
                     if (method == UnityRandomRangeInt || method == UnityRandomRangeIntObsolete)
+                    {
                         ci.operand = VerseRandomRangeInt;
+                        anythingPatched = true;
+                    }
                     else if (method == UnityRandomRangeFloat || method == UnityRandomRangeFloatObsolete)
+                    {
                         ci.operand = VerseRandomRangeFloat;
+                        anythingPatched = true;
+                    }
                     else if (method == UnityRandomValue)
+                    {
                         ci.operand = VerseRandomValue;
+                        anythingPatched = true;
+                    }
                     else if (method == UnityInsideUnitCircle)
+                    {
                         ci.operand = VerseInsideUnitCircle;
+                        anythingPatched = true;
+                    }
                 }
 
                 yield return ci;
             }
+
+            if (!anythingPatched) Log.Warning($"No Unity RNG was patched for method: {original?.FullDescription() ?? "(unknown method)"}");
         }
         #endregion
     }


### PR DESCRIPTION
PatchingUtilities changes:
- RNG transpilers now give a warning when no RNG was patched at all
- use IEnumerable<T> instead of arrays
- check for declared constructor first when patching them by type name
- changed methods to method in a few places in XML docs
- changed type to typeName in a few method parameters and XML docs