### PR TITLE
Reworked dialog closing syncing and pause locks

### DIFF
--- a/Source/DialogUtilities.cs
+++ b/Source/DialogUtilities.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    public static class DialogUtilities
+    {
+        private static bool isCloseSyncInitialized = false;
+        private static bool isPauseLockInitialized = false;
+        private static readonly List<Window> OpenDialogsCloseSync = new();
+        private static readonly List<Window> OpenPauseLockDialogs = new();
+
+        /// <summary>
+        /// Registers a dialog (by patching declared constructors it has) to sync the
+        /// interaction of closing the dialog.
+        ///
+        /// This should be used if a dialog allows for being closed by shortcuts like
+        /// pressing escape/enter to cancel/accept, as well as cases where syncing the
+        /// button or interaction to close it is in an inaccessible or hard to access
+        /// location for syncing purposes.
+        ///
+        /// This also allows for adding a pause lock when the dialog is open.
+        /// </summary>
+        /// <param name="type">The type to be registered for synced closing.</param>
+        /// <param name="addPauseLock">If true, the type will also be registered to pause locking.</param>
+        public static void RegisterDialogCloseSync(Type type, bool addPauseLock = false)
+        {
+            if (type == null) return;
+
+#if DEBUG
+            Log.Message($"Registering dialog close sync type: {type.FullName}");
+#endif
+
+            InitializeDialogCloseSync(addPauseLock);
+
+            var patch = addPauseLock
+                ? new HarmonyMethod(typeof(DialogUtilities), nameof(PostDialogOpen_CloseSync_PauseLock))
+                : new HarmonyMethod(typeof(DialogUtilities), nameof(PostDialogOpen_CloseSync));
+
+            foreach (var ctor in AccessTools.GetDeclaredConstructors(type))
+                MpCompat.harmony.Patch(ctor, postfix: patch);
+        }
+
+        /// <summary>
+        /// Registers a dialog (by patching declared constructors it has) to pause the
+        /// game while it's open.
+        ///
+        /// This should be used instead of <see cref="RegisterDialogCloseSync"/> when
+        /// the interaction of closing the dialog is guaranteed to be synced and it
+        /// doesn't require special handling.
+        /// </summary>
+        /// <param name="type">The type to be registered for pause lock.</param>
+        public static void RegisterPauseLock(Type type)
+        {
+            if (type == null) return;
+
+            InitializeDialogPauseLock();
+
+#if DEBUG
+            Log.Message($"Registering pause lock type: {type.FullName}");
+#endif
+
+            foreach (var ctor in AccessTools.GetDeclaredConstructors(type))
+                MpCompat.harmony.Patch(ctor, postfix: new HarmonyMethod(typeof(DialogUtilities), nameof(PostDialogOpen_PauseLock)));
+        }
+
+        public static void InitializeDialogCloseSync(bool addPauseLock)
+        {
+            // Only register the pause lock if any of the dialogs requires pause lock
+            if (addPauseLock)
+                InitializeDialogPauseLock();
+
+            // If we've patched the WindowStack.TryRemove method, make sure we don't do it again.
+            if (isCloseSyncInitialized) return;
+
+            MP.RegisterSyncMethod(typeof(DialogUtilities), nameof(SyncedTryCloseDialog));
+
+            MpCompat.harmony.Patch(AccessTools.Method(typeof(WindowStack), nameof(WindowStack.TryRemove), new[] { typeof(Window), typeof(bool) }),
+                prefix: new HarmonyMethod(typeof(DialogUtilities), nameof(PreTryRemove)));
+            // Notify_ClickedInsideWindow is removing the window, but then inserting it into the list
+            // at a different position right after. No need to touch that one at all.
+            // We're assuming it won't fail doing it.
+
+            isCloseSyncInitialized = true;
+        }
+
+        public static void InitializeDialogPauseLock()
+        {
+            if (isPauseLockInitialized) return;
+            
+            MP.RegisterPauseLock(IsPausingDialogOpen);
+            isPauseLockInitialized = true;
+        }
+
+        private static bool IsPausingDialogOpen(Map _)
+        {
+            // If no pausing dialogs are open, we just return false.
+            // This way it should have a minimal impact on performance.
+            if (!OpenPauseLockDialogs.Any()) return false;
+
+            // Remove all null or closed dialogs.
+            // Should help situations when, for whatever reason, the dialog was without TryRemove call.
+            // This will end up with a slight more performance impact, but considering
+            // the game will be paused anyway: it won't be noticeable.
+            OpenPauseLockDialogs.RemoveAll(x => x is not { IsOpen: true });
+            return OpenPauseLockDialogs.Any();
+        }
+
+        public static void PostDialogOpen_CloseSync(Window __instance)
+            => OpenDialogsCloseSync.AddDistinct(__instance);
+
+        public static void PostDialogOpen_PauseLock(Window __instance)
+            => OpenPauseLockDialogs.AddDistinct(__instance);
+
+        public static void PostDialogOpen_CloseSync_PauseLock(Window __instance)
+        {
+            OpenDialogsCloseSync.AddDistinct(__instance);
+            OpenPauseLockDialogs.AddDistinct(__instance);
+        }
+
+        private static bool PreTryRemove(Window window, bool doCloseSound)
+        {
+            if (!MP.IsInMultiplayer)
+                return true;
+
+            if (MP.IsExecutingSyncCommand)
+            {
+                // Try removing the dialog from pause lock dialogs
+                OpenPauseLockDialogs.Remove(window);
+                return true;
+            }
+
+            var index = OpenDialogsCloseSync.IndexOf(window);
+
+            if (index < 0)
+            {
+                // If it's not in OpenDialogs, it means it may only registered pause locking only.
+                OpenPauseLockDialogs.Remove(window);
+                return true;
+            }
+
+            SyncedTryCloseDialog(index, doCloseSound);
+            return false;
+        }
+
+        private static void SyncedTryCloseDialog(int index, bool doCloseSound)
+        {
+            if (index >= 0 && OpenDialogsCloseSync.Count > index)
+            {
+                var window = OpenDialogsCloseSync[index];
+                OpenDialogsCloseSync.RemoveAt(index); // Remove the window from our list just in case removing will fail
+                Find.WindowStack.TryRemove(window, doCloseSound);
+            }
+        }
+    }
+}

--- a/Source/Mods/HealerMechSerumChoice.cs
+++ b/Source/Mods/HealerMechSerumChoice.cs
@@ -29,22 +29,8 @@ namespace Multiplayer.Compat
             MpCompat.harmony.Patch(AccessTools.Method(hediffSelectionDialogType, nameof(Window.DoWindowContents)),
                 prefix: new HarmonyMethod(typeof(HealerMechSerumChoice), nameof(PreDoWindowContents)),
                 postfix: new HarmonyMethod(typeof(HealerMechSerumChoice), nameof(PostDoWindowContents)));
-            MpCompat.harmony.Patch(AccessTools.Constructor(hediffSelectionDialogType, new[] { typeof(string), typeof(List<Hediff>), typeof(Action<Hediff>) }),
-                postfix: new HarmonyMethod(typeof(HealerMechSerumChoice), nameof(PostDialogConstructor)));
 
-            MP.RegisterPauseLock(PauseWhenDialogOpen);
-        }
-
-        // Prevent the dialog from being closed by pressing esc/enter (or other assigned button)
-        // Only allow closing it from the cancel button in the dialog
-        // Otherwise we'd have to patch Window.Close or WindowStack.TryRemove and sync the closing of them
-        private static void PostDialogConstructor(Window __instance)
-        {
-            if (!MP.IsInMultiplayer)
-                return;
-
-            __instance.closeOnCancel = false;
-            __instance.closeOnAccept = false;
+            DialogUtilities.RegisterDialogCloseSync(hediffSelectionDialogType, true);
         }
 
         private static void PreDoWindowContents(Hediff ___SelectedHediff, ref Hediff __state)
@@ -78,10 +64,5 @@ namespace Multiplayer.Compat
             if (!sync.isWriting)
                 window = Find.WindowStack.Windows.FirstOrDefault(x => x.GetType() == hediffSelectionDialogType);
         }
-
-        // Once we add non-blocking dialogs to the API
-        // we should apply this only to the map it's used on
-        private static bool PauseWhenDialogOpen(Map map)
-            => Find.WindowStack.IsOpen(hediffSelectionDialogType);
     }
 }

--- a/Source/Mods/VanillaFactionsPirates.cs
+++ b/Source/Mods/VanillaFactionsPirates.cs
@@ -73,7 +73,9 @@ namespace Multiplayer.Compat
                 armorColorField = AccessTools.FieldRefAccess<Color>(type, "colorArmor");
 
                 MP.RegisterSyncMethod(typeof(VanillaFactionsPirates), nameof(SyncedSetColors));
-                MP.RegisterPauseLock(PauseIfDialogOpen);
+                // This dialog should most likely not react to pressing enter/esc (or whatever those were assigned to).
+                // Sounds like an oversight on VE team.
+                DialogUtilities.RegisterDialogCloseSync(warcasketDialogType, true);
             }
 
             // Curse window
@@ -228,10 +230,5 @@ namespace Multiplayer.Compat
                 yield return ci;
             }
         }
-
-        // Once we add non-blocking dialogs to the API
-        // we should apply this only to the map it's used on
-        private static bool PauseIfDialogOpen(Map map)
-            => Find.WindowStack.IsOpen(warcasketDialogType);
     }
 }

--- a/Source/Mods/VanillaFactionsVikings.cs
+++ b/Source/Mods/VanillaFactionsVikings.cs
@@ -65,7 +65,7 @@ namespace Multiplayer.Compat
             MpCompat.harmony.Patch(AccessTools.Method(typeof(WindowStack), nameof(WindowStack.TryRemove), new[] { typeof(Window), typeof(bool) }),
                 prefix: new HarmonyMethod(typeof(VanillaFactionsVikings), nameof(PreTryRemoveWindow)));
 
-            MP.RegisterPauseLock(PauseIfDialogOpen);
+            DialogUtilities.RegisterDialogCloseSync(changeFacepaintDialogType, true);
         }
 
         private static void PreDoWindowContents(Window __instance)
@@ -131,10 +131,5 @@ namespace Multiplayer.Compat
                     dialog = Find.WindowStack.Windows.First(x => x.GetType() == changeFacepaintDialogType);
             }
         }
-
-        // Once we add non-blocking dialogs to the API
-        // we should apply this only to the map it's used on
-        private static bool PauseIfDialogOpen(Map map)
-            => Find.WindowStack.IsOpen(changeFacepaintDialogType);
     }
 }

--- a/Source/Mods/VanillaHairExpanded.cs
+++ b/Source/Mods/VanillaHairExpanded.cs
@@ -52,7 +52,7 @@ namespace Multiplayer.Compat
             MpCompat.harmony.Patch(AccessTools.Method(typeof(WindowStack), nameof(WindowStack.TryRemove), new[] { typeof(Window), typeof(bool) }),
                 prefix: new HarmonyMethod(typeof(VanillaHairExpanded), nameof(PreTryRemoveWindow)));
 
-            MP.RegisterPauseLock(PauseIfDialogOpen);
+            DialogUtilities.RegisterDialogCloseSync(changeHairstyleDialogType, true);
         }
 
         private static void PreDoWindowContents(Window __instance)
@@ -115,10 +115,5 @@ namespace Multiplayer.Compat
                     dialog = Find.WindowStack.Windows.First(x => x.GetType() == changeHairstyleDialogType);
             }
         }
-
-        // Once we add non-blocking dialogs to the API
-        // we should apply this only to the map it's used on
-        private static bool PauseIfDialogOpen(Map map) 
-            => Find.WindowStack.IsOpen(changeHairstyleDialogType);
     }
 }


### PR DESCRIPTION
The new class DialogUtilities handles all the new functionality. It will patch constructor of dialogs of specified type, which will add the open dialog to the list of open dialogs for closing and/or pause locks.

We have a prefix patch to WindowStack.TryRemove, which - if the dialog is inside of the list for close syncing - will stop it from being closed and instead do it in synced context. In case of pausing dialogs it'll remove it from the list of those (if it's also a dialog that sync closing - it'll do it after synced close).

As for pause lock - using a single pause lock for all dialogs should help with performance - as MP will no longer have to iterate over however many pause locks we registered - and instead check if the list of pausing dialogs is empty or not. In case it's locking the pause, it'll also try removing all null or closed dialogs, to prevent situations where the dialog was not properly removed from the list.

This also goes through (almost) all mods that had pause locks in place, and modifies them to use this new way of handling those. This change significantly simplifies those patches, as there's no longer need to handle situations where code closing the dialog is inaccessible/hard to access.