### PR TITLE
Synced new abilities added in VFE-Pirates

### DIFF
--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -76,7 +76,7 @@ namespace Multiplayer.Compat
                 (PatchItemProcessor, "Item Processor", false),
                 (PatchOtherRng, "Other RNG", false),
                 (PatchVFECoreDebug, "Debug Gizmos", false),
-                (PatchAbilities, "Abilities", false),
+                (PatchAbilities, "Abilities", true),
                 (PatchHireableFactions, "Hireable Factions", false),
                 (PatchVanillaFurnitureExpanded, "Vanilla Furniture Expanded", false),
                 (PatchVanillaFactionMechanoids, "Vanilla Faction Mechanoids", false),
@@ -182,6 +182,10 @@ namespace Multiplayer.Compat
             MpCompat.harmony.Patch(AccessTools.Method(type, "DoAction"),
                 prefix: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(PreAbilityDoAction)),
                 postfix: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(PostAbilityDoAction)));
+
+            type = AccessTools.TypeByName("VFECore.CompShieldField");
+            MpCompat.RegisterLambdaMethod(type, nameof(ThingComp.CompGetWornGizmosExtra), 0);
+            MpCompat.RegisterLambdaMethod(type, "GetGizmos", 0, 2);
         }
 
         private static void PatchHireableFactions()

--- a/Source/Mods/VanillaFactionsPirates.cs
+++ b/Source/Mods/VanillaFactionsPirates.cs
@@ -45,6 +45,14 @@ namespace Multiplayer.Compat
             {
                 // Enable/disable siege mode
                 MpCompat.RegisterLambdaMethod("VFEPirates.Ability_SiegeMode", "GetGizmo", 0, 2);
+                MP.RegisterSyncMethod(AccessTools.Method("VFEPirates.Verb_DroneDeployment:ReleaseDrones"));
+
+                // The code using the ability returns true, and we need to make sure it happens because
+                // as far as I understand, sync method on non-void methods returns default value (which
+                // would be false for bool)
+                MP.RegisterSyncMethod(typeof(VanillaFactionsPirates), nameof(SyncedShieldDetonation));
+                MpCompat.harmony.Patch(AccessTools.Method("VFEPirates.Verb_ShieldDetonation:TryCastShot"),
+                    prefix: new HarmonyMethod(typeof(VanillaFactionsPirates), nameof(PreShieldDetonation)));
             }
 
             // Warcasket dialog
@@ -233,5 +241,22 @@ namespace Multiplayer.Compat
         // we should apply this only to the map it's used on
         private static bool PauseIfDialogOpen(Map map)
             => Find.WindowStack.IsOpen(warcasketDialogType);
+
+        private static bool PreShieldDetonation(Verb __instance, ref bool __result)
+        {
+            if (!MP.IsInMultiplayer || MP.IsExecutingSyncCommand)
+                return true;
+
+            // We need to sync as ThingComp, as MP only supports 2 comps - CompEquippable and CompReloadable
+            SyncedShieldDetonation((ThingComp)__instance.DirectOwner, __instance.loadID);
+            __result = true;
+            return false;
+        }
+
+        private static void SyncedShieldDetonation(ThingComp verbGiverComp, string loadId)
+        {
+            var verb = ((IVerbOwner)verbGiverComp).VerbTracker.AllVerbs.Find(ve => ve.loadID == loadId);
+            verb.TryCastShot();
+        }
     }
 }


### PR DESCRIPTION
The new abilities are:

- Deploy Low-Shield
- Deploy Wardrones
- Shield Detonation

The mod update that added those also added "Deploy Spidermine" ability, but that one works fine without any changes.