### PR TITLE
Added compat for Rim-Effect mods

### DIFF
--- a/Source/Mods/RimEffectCore.cs
+++ b/Source/Mods/RimEffectCore.cs
@@ -1,0 +1,45 @@
+﻿using System.Reflection;
+using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Rim-Effect: Core by Vanilla Expanded Team and Co.</summary>
+    /// <see href="https://github.com/AndroidQuazar/RimEffect-Core"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2479560240"/>
+    [MpCompatFor("RimEffect.Core")]
+    public class RimEffectCore
+    {
+        private static ConstructorInfo doorValueCtor;
+        private static FieldInfo doorValueKeyField;
+
+        public RimEffectCore(ModContentPack mod)
+        {
+            // May need patching:
+            // AddHumanlikeOrders_Patch - free hostages
+            // RimEffect.CompSpawnOnInteract - open
+
+            MpCompat.RegisterLambdaMethod("RimEffect.AmmoBelt", "GetWornGizmos", 1);
+
+            var autoDoorType = AccessTools.TypeByName("RimEffect.Building_AutoDoorLockable");
+            var method = MpMethodUtil.GetLambda(autoDoorType, "GetGizmos", lambdaOrdinal: 1);
+            var field = AccessTools.Field(method.DeclaringType, "doorState");
+            var doorValueType = field.FieldType;
+            var genericTypes = doorValueType.GetGenericArguments();
+            doorValueCtor = AccessTools.DeclaredConstructor(doorValueType, new[] { genericTypes[0], genericTypes[1] });
+            doorValueKeyField = AccessTools.Field(doorValueType, "key");
+
+            MP.RegisterSyncDelegate(autoDoorType, method.DeclaringType.Name, method.Name);
+            MP.RegisterSyncWorker<object>(SyncDoorValue, doorValueType);
+        }
+
+        private static void SyncDoorValue(SyncWorker sync, ref object doorValue)
+        {
+            if (sync.isWriting)
+                sync.Write((int)doorValueKeyField.GetValue(doorValue));
+            else
+                doorValue = doorValueCtor.Invoke(new object[] { sync.Read<int>(), string.Empty });
+        }
+    }
+}

--- a/Source/Mods/RimEffectDrell.cs
+++ b/Source/Mods/RimEffectDrell.cs
@@ -1,0 +1,14 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Rim-Effect: Drell by Vanilla Expanded Team and Co.</summary>
+    /// <see href="https://github.com/AndroidQuazar/RimEffect-Drell"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2651150217"/>
+    [MpCompatFor("RimEffect.Drell")]
+    public class RimEffectDrell
+    {
+        public RimEffectDrell(ModContentPack mod) 
+            => MpCompat.RegisterLambdaMethod("REDrell.Comp_Drell", "CompGetGizmosExtra", 0, 1);
+    }
+}

--- a/Source/Mods/RimEffectExtendedCut.cs
+++ b/Source/Mods/RimEffectExtendedCut.cs
@@ -1,0 +1,17 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Rim-Effect: Extended Cut by Vanilla Expanded Team and Co.</summary>
+    /// <see href="https://github.com/Helixien/RimEffect-ExtendedCut"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2479492267"/>
+    [MpCompatFor("RimEffect.ExtendedCut")]
+    public class RimEffectExtendedCut
+    {
+        public RimEffectExtendedCut(ModContentPack mod)
+        {
+            MpCompat.RegisterLambdaDelegate("RimEffectExtendedCut.Building_WarzoneTable", "GetBattleSetOptions", 0);
+            MpCompat.RegisterLambdaMethod("RimEffectExtendedCut.CompPowerOutDoorLamp", "CompGetGizmosExtra", 0, 1).SetDebugOnly();
+        }
+    }
+}


### PR DESCRIPTION
This should handle everything in the Rim-Effect mods that needs patching, with 1 exception - quest menu from galaxy map.

That feature requires patching Vanilla Expanded Framework, and is bit more complex than the rest of the patches. Leaving it for later.