### PR TITLE
Updated debug actions and reference builder

### DIFF
--- a/Source/MpCompat.cs
+++ b/Source/MpCompat.cs
@@ -11,15 +11,14 @@ namespace Multiplayer.Compat
 {
     public class MpCompat : Mod
     {
-        const string REFERENCES_FOLDER = "References";
         public static readonly Harmony harmony = new Harmony("rimworld.multiplayer.compat");
 
         public MpCompat(ModContentPack content) : base(content)
         {
+            DebugActions.content = content;
+
             if (!MP.enabled) {
-                Log.Warning($"MPCompat :: Multiplayer is disabled. Running in Reference Building mode.\nPut any reference building requests under {REFERENCES_FOLDER} as {{DLLNAME}}.txt");
-                ReferenceBuilder.Restore(Path.Combine(content.RootDir, REFERENCES_FOLDER));
-                Log.Warning($"MPCompat :: Done Rebuilding. Bailing out...");
+                Log.Warning("MPCompat :: Multiplayer is disabled.");
                 return;
             }
 

--- a/Source/ReferenceBuilder.cs
+++ b/Source/ReferenceBuilder.cs
@@ -1,42 +1,75 @@
-﻿using System;
-using System.Diagnostics;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
 using Verse;
 
 namespace Multiplayer.Compat
 {
     static class ReferenceBuilder
     {
-        public static void Restore(string refsFolder)
+        private enum BuildResult
         {
-            var requestedFiles = Directory.CreateDirectory(refsFolder).GetFiles("*.txt");
-
-            foreach(var request in requestedFiles)
-            {
-                BuildReference(refsFolder, request);
-            }
+            Success,
+            Skipped,
+            Failure,
         }
 
-        static void BuildReference(string refsFolder, FileInfo request)
+        public static (int successes, int skipped, int failures) Restore(string refsFolder)
+        {
+            var requestedFiles = Directory.CreateDirectory(refsFolder).GetFiles("*.txt");
+            var successes = 0;
+            var skipped = 0;
+            var failures = 0;
+
+            foreach (var request in requestedFiles)
+            {
+                switch (BuildReference(refsFolder, request))
+                {
+                    case BuildResult.Success:
+                        successes++;
+                        break;
+                    case BuildResult.Skipped:
+                        skipped++;
+                        break;
+                    case BuildResult.Failure:
+                    default:
+                        failures++;
+                        break;
+                }
+            }
+
+            return (successes, skipped, failures);
+        }
+
+        private static BuildResult BuildReference(string refsFolder, FileInfo request)
         {
             var asmId = Path.GetFileNameWithoutExtension(request.Name);
+            Log.Warning($"Trying to write:\nFile: {request.FullName}\nAssembly: {asmId}");
 
             var assembly = LoadedModManager.RunningModsListForReading
                 .SelectMany(m => ModContentPack.GetAllFilesForModPreserveOrder(m, "Assemblies/", f => f.ToLower() == ".dll"))
                 .FirstOrDefault(f => f.Item2.Name == asmId + ".dll")?.Item2;
-            
+
+            if (assembly == null)
+            {
+                Log.Warning("Null assembly found, skipping");
+                return BuildResult.Failure;
+            }
+
             var hash = ComputeHash(assembly.FullName);
             var hashFile = Path.Combine(refsFolder, asmId + ".txt");
 
             if (File.Exists(hashFile) && File.ReadAllText(hashFile) == hash)
-                return;
-            
-            Console.WriteLine($"MpCompat References: Writing {asmId}.dll");
-            
+            {
+                Log.Warning($"Hashes are matching, skipping. Hash: {hash}");
+                return BuildResult.Skipped;
+            }
+
+            Log.Warning($"MpCompat References: Writing {asmId}.dll");
+
             var outFile = Path.Combine(refsFolder, asmId + ".dll");
             var asmDef = AssemblyDefinition.ReadAssembly(assembly.FullName);
 
@@ -50,7 +83,7 @@ namespace Multiplayer.Compat
                 foreach (var m in t.Methods)
                 {
                     m.IsPublic = true;
-                    m.Body = new Mono.Cecil.Cil.MethodBody(m);
+                    m.Body = new MethodBody(m);
                 }
 
                 foreach (var f in t.Fields)
@@ -59,20 +92,21 @@ namespace Multiplayer.Compat
                     f.IsPublic = true;
                 }
             }
-            
+
             asmDef.Write(outFile);
             File.WriteAllText(hashFile, hash);
+            return BuildResult.Success;
         }
 
-        static string ComputeHash(string assemblyPath)
+        private static string ComputeHash(string assemblyPath)
         {
             var res = new StringBuilder();
 
             using var hash = SHA1.Create();
             using FileStream file = File.Open(assemblyPath, FileMode.Open, FileAccess.Read);
-            
+
             hash.ComputeHash(file);
-            
+
             foreach (byte b in hash.Hash)
                 res.Append(b.ToString("X2"));
 


### PR DESCRIPTION
- Removed reference building when MP is disabled, made it a debug action
- Added a check for null assembly in reference builder
- Added some extra logging to reference builder
- Added a new check for UnityEngine.Time when looking for unsupported stuff
- Used PatchProcessor.GetCurrentInstructions to look through the method, instead of using a transpiler
- Added a check if a method returns System.MonoFNPtrFakeClass, as those methods cause crashing
- Added a check if methods have a method body
- Some other minor stuff