### PR TITLE
temporarily fixed zombieland compat

### DIFF
--- a/Source_Referenced/ZombieLand.cs
+++ b/Source_Referenced/ZombieLand.cs
@@ -27,9 +27,6 @@ namespace Multiplayer.Compat
 
             var transpiler = new HarmonyMethod(typeof(ZombieLand), nameof(ReplaceCoroutineCall));
             MpCompat.harmony.Patch(
-                AccessTools.Method(typeof(ZombieGenerator), nameof(ZombieGenerator.SpawnZombie)),
-                transpiler: transpiler);
-            MpCompat.harmony.Patch(
                 AccessTools.Method(typeof(ZombiesRising), nameof(ZombiesRising.TryExecute)),
                 transpiler: transpiler);
             MpCompat.harmony.Patch(


### PR DESCRIPTION
fix: Removed replacement for coroutine_call on ZombieGenerator.SpawnZombie as it is not using coroutine anymore.
It seems work well in game. But I still got warning said "Failed to fully patch ZombieLand coroutine." and I'm no sure how Sokyran affirm this. So... I called this a "temporarily fix".