### PR TITLE
Fixed Giddy Up 2 compat

### DIFF
--- a/Source/Mods/GiddyUp2.cs
+++ b/Source/Mods/GiddyUp2.cs
@@ -40,8 +40,8 @@ namespace Multiplayer.Compat
 
             // FloatMenus
             {
-                // Dismount/Mount/Switch mount/Godmode mount
-                MpCompat.RegisterLambdaDelegate("GiddyUp.Harmony.FloatMenuUtility", "AddMountingOptions", 0, 1, 2, 3).Last().SetDebugOnly();
+                // Dismount/Mount/Switch mount
+                MpCompat.RegisterLambdaDelegate("GiddyUp.Harmony.FloatMenuUtility", "AddMountingOptions", 0, 1, 2);
 
                 // Select/clear rider pawn for caravan
                 var type = AccessTools.TypeByName("GiddyUpCaravan.Harmony.Patch_TransferableOneWayWidget");


### PR DESCRIPTION
It seems the dev mode mount option was dropped, although the github repo seems to not have this change just yet