### PR TITLE
Added compat for Alpha Mythology

### DIFF
--- a/Source/Mods/AlphaMythology.cs
+++ b/Source/Mods/AlphaMythology.cs
@@ -1,0 +1,14 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Alpha Mythology by Sarg Bjornson</summary>
+    /// <see href="https://github.com/juanosarg/AlphaMythology"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1821617793"/>
+    [MpCompatFor("sarg.magicalmenagerie")]
+    public class AlphaMythology
+    {
+        public AlphaMythology(ModContentPack mod) 
+            => PatchingUtilities.PatchSystemRandCtor("AnimalBehaviours.DeathActionWorker_ExplodeAndSpawnEggs");
+    }
+}


### PR DESCRIPTION
Also requires #285, as it uses problematic stuff from Vanilla Expanded Framework (the method `VanillaCookingExpanded.Thought_Hediff:MoodOffset`)