### PR TITLE
Fixed remove/add forced apparel in RPG Style Inventory Revamped

### DIFF
--- a/Source/Mods/RPGStyleInventory.cs
+++ b/Source/Mods/RPGStyleInventory.cs
@@ -25,7 +25,7 @@ namespace Multiplayer.Compat
             MP.RegisterSyncMethod(type, "InterfaceIngest").SetContext(SyncContext.MapSelected);
 
             // Remove/add forced apparel
-            if (mod.PackageId == "Sandy.RPGStyleInventory.avilmask.Revamped") {
+            if (mod.PackageId == "Sandy.RPGStyleInventory.avilmask.Revamped".ToLower()) {
                 MpCompat.RegisterLambdaDelegate(type, "PopupMenu", 1, 2);
             }
         }


### PR DESCRIPTION
`ModContentPack.PackageId` is lowercase by default.

I've opted for calling `.ToLower()` instead of changing the string itself for consistency with the ID for the `MpCompatFor` attribute.