### PR TITLE
Compat for Vanilla Helixien Gas Expanded

### DIFF
--- a/Source/Mods/VanillaHelixienGas.cs
+++ b/Source/Mods/VanillaHelixienGas.cs
@@ -1,0 +1,19 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Vanilla Helixien Gas Expanded by Oskar Potocki, Kikohi</summary>
+    /// <see href="https://github.com/Vanilla-Expanded/VanillaHelixienGasExpanded"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2877699803"/>
+    [MpCompatFor("VanillaExpanded.HelixienGas")]
+    public class VanillaHelixienGasExpanded
+    {
+        public VanillaHelixienGasExpanded(ModContentPack mod)
+        {
+            // Fill gizmo
+            MpCompat.RegisterLambdaMethod("VHelixienGasE.Building_GasGeyser", "GetGizmos", 0);
+            // GenView.ShouldSpawnMotesAt call with RNG calls, need to push/pop
+            PatchingUtilities.PatchPushPopRand("VHelixienGasE.IntermittentGasSprayer:ThrowGasPuffUp");
+        }
+    }
+}

--- a/Source/Mods/VanillaNutrientPasteExpanded.cs
+++ b/Source/Mods/VanillaNutrientPasteExpanded.cs
@@ -2,11 +2,9 @@
 
 namespace Multiplayer.Compat
 {
-    /// <summary>
-    /// Vanilla Nutrient Paste Expanded by Oskar Potocki, Kikohi
-    /// Seems it's not on GitHub anymore?
+    /// <summary>Vanilla Nutrient Paste Expanded by Oskar Potocki, Kikohi</summary>
+    /// <see href="https://github.com/Vanilla-Expanded/VanillaNutrientPasteExpanded"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2920385763"/>
-    /// </summary>
     [MpCompatFor("VanillaExpanded.VNutrientE")]
     public class VanillaNutrientPasteExpanded
     {


### PR DESCRIPTION
One of the recent updates re-added the gas vents. It needed syncing gizmo (to fill it) as well as the usage of `GenView.ShouldSpawnMotesAt` as it causes issues with multiple maps.

Also seems like I had a commit ready that I forgot to push, and it ended up being pushed with this one... Oops. It's a small change to comments in Vanilla Nutrient Paste Expanded - added github link to the mod (since it was finally put on git again).