### PR TITLE
Patched special terrain from Vanilla Expanded Framework

### DIFF
--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -122,6 +122,7 @@ namespace Multiplayer.Compat
                 (PatchVanillaGenesExpanded, "Vanilla Genes Expanded", false),
                 (PatchVanillaCookingExpanded, "Vanilla Cooking Expanded", false),
                 (PatchDoorTeleporter, "Teleporter Doors", true),
+                (PatchSpecialTerrain, "Special Terrain", false),
             };
 
             foreach (var (patchMethod, componentName, latePatch) in patches)
@@ -926,6 +927,26 @@ namespace Multiplayer.Compat
 
                 yield return ci;
             }
+        }
+
+        #endregion
+
+        #region Special Terrain
+
+        private static void PatchSpecialTerrain()
+        {
+            MpCompat.harmony.Patch(AccessTools.DeclaredMethod("VFECore.SpecialTerrainList:TerrainUpdate"),
+                prefix: new HarmonyMethod(typeof(BiomesCore), nameof(RemoveTerrainUpdateTimeBudget)));
+        }
+
+        private static void RemoveTerrainUpdateTimeBudget(ref long timeBudget)
+        {
+            if (MP.IsInMultiplayer)
+                timeBudget = long.MaxValue; // Basically limitless time
+
+            // The method is limited in updating a max of 1/3 of all active special terrains.
+            // If we'd want to work on having a performance option of some sort, we'd have to
+            // base it around amount of terrain updates per tick, instead of basing it on actual time.
         }
 
         #endregion


### PR DESCRIPTION
The terrain was using real-life time and speed of the PC that was running to end processing the terrain early if it was taking too long.

For obvious reasons, this causes with MP - if a terrain tile for example pushes heat when ticking (like lava from ReGrowth: Core) - then if it only happens for one person would be bad.

There are also situations where terrain ticking would not be problematic - things like non-ticking comps, or comps that only change the visuals (potentially mote-spawning comps).

On the negative side - this could potentially lower the performance if there's a lot of special terrains. Sadly, this is a price we'll have to pay to remove desyncs related to special terrain.

Oh, and final thing - I put it in a new region. I plan to put new patches (and at some point split the old ones) into separate region for easier management.