### PR TITLE
General maintenance to Vanilla Expanded mod patches

### DIFF
--- a/Source/Mods/VanillaBrewingExpanded.cs
+++ b/Source/Mods/VanillaBrewingExpanded.cs
@@ -10,7 +10,6 @@ namespace Multiplayer.Compat
     {
         public VanillaBrewingExpanded(ModContentPack mod)
         {
-            PatchingUtilities.PatchSystemRand("VanillaBrewingExpanded.Plant_AutoProduce:TickLong");
             PatchingUtilities.PatchSystemRandCtor("VanillaBrewingExpanded.Hediff_ConsumedCocktail");
         }
     }

--- a/Source/Mods/VanillaEventsExpanded.cs
+++ b/Source/Mods/VanillaEventsExpanded.cs
@@ -1,4 +1,5 @@
-﻿using Verse;
+﻿using RimWorld;
+using Verse;
 
 namespace Multiplayer.Compat
 {
@@ -11,6 +12,8 @@ namespace Multiplayer.Compat
     {
         public VEE(ModContentPack mod)
         {
+            MpSyncWorkers.Requires<GameCondition>();
+
             var methodsForAll = new[]
             {
                 "VEE.RegularEvents.ApparelPod:TryExecuteWorker",
@@ -27,6 +30,15 @@ namespace Multiplayer.Compat
 
             // Unity RNG
             PatchingUtilities.PatchUnityRand("VEE.Shuttle:Tick");
+
+            // Current map usage, picks between rain and snow based on current map temperature, instead of using map it affects
+            PatchingUtilities.ReplaceCurrentMapUsage("VEE.PurpleEvents.PsychicRain:ForcedWeather");
+
+            // Reset game conditions - technically does not require debug mode,
+            // but lets you end (almost?) any game condition at any time
+            // so I'd consider it close enough to justify `SetDebugOnly` on it.
+            MpCompat.RegisterLambdaDelegate("VEE.Settings.VEESettings", "ResetWorldCondButton", 0).SetDebugOnly();
+            MpCompat.RegisterLambdaDelegate("VEE.Settings.VEESettings", "ResetMapCondButton", 0).SetDebugOnly();
 
             LongEventHandler.ExecuteWhenFinished(LatePatch);
         }

--- a/Source/Mods/VanillaFurnitureExpandedSecurity.cs
+++ b/Source/Mods/VanillaFurnitureExpandedSecurity.cs
@@ -1,13 +1,6 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using HarmonyLib;
+﻿using HarmonyLib;
 using Multiplayer.API;
-using RimWorld;
-using RimWorld.Planet;
 using Verse;
-using Verse.Sound;
 
 namespace Multiplayer.Compat
 {
@@ -18,37 +11,17 @@ namespace Multiplayer.Compat
     [MpCompatFor("VanillaExpanded.VFESecurity")]
     class VFESecurity
     {
-        private static PropertyInfo selectedCompsProperty;
-        private static AccessTools.FieldRef<object, GlobalTargetInfo> targetedTileField;
-        private static MethodInfo resetWarmupTicksMethod;
-
         public VFESecurity(ModContentPack mod)
         {
+            LongEventHandler.ExecuteWhenFinished(LateSyncMethods);
+
+            // 2 of the overloads of VFESecurity.TrenchUtility:FinalAdjustedRangeFromTerrain use `Find.CurrentMap`
+            // which would normally cause issues, but they are unused by the mod at all.
+
             // RNG fix
             {
-                var methodNames = new[]
-                {
-                    "VFESecurity.ArtilleryStrikeArrivalAction_AIBase:Arrived",
-                    "VFESecurity.ArtilleryStrikeArrivalAction_Insectoid:StrikeAction",
-                    "VFESecurity.ArtilleryStrikeArrivalAction_Map:Arrived",
-                    "VFESecurity.ArtilleryStrikeArrivalAction_Outpost:StrikeAction",
-                    "VFESecurity.ArtilleryStrikeArrivalAction_PeaceTalks:Arrived",
-                    "VFESecurity.ArtilleryStrikeArrivalAction_Settlement:StrikeAction",
-                    "VFESecurity.WorldObjectCompProperties_Artillery:ArtilleryCountFor",
-                    // ArtilleryStrikeUtility:GetRandomShellFor and ArtilleryStrikeUtility:PotentialStrikeCells are only called by methods that are patched already
-                    "VFESecurity.Building_BarbedWire:SpringSub",
-                    "VFESecurity.Building_TrapBear:SpringSub",
-                    // This one seems like it should have no random calls at all in its hierarchy, but desync traces show that there are actually some.
-                    "VFESecurity.Verb_Dazzle:TryCastShot",
-                    "NoCamShakeExplosions.DamageWorker_FlameNoCamShake:Apply",
-                    "NoCamShakeExplosions.DamageWorker_FlameNoCamShake:ExplosionAffectCell",
-                    // Motes
-                    "VFESecurity.ExtendedMoteMaker:SearchlightEffect",
-                };
-
-                PatchingUtilities.PatchPushPopRand(AccessTools.Method(AccessTools.Inner(AccessTools.TypeByName("VFESecurity.Patch_Building_Trap"), "Spring"), "ShouldDestroy"));
-                PatchingUtilities.PatchPushPopRand(methodNames);
-                LongEventHandler.ExecuteWhenFinished(LateSyncMethods);
+                // Motes
+                PatchingUtilities.PatchPushPopRand("VFESecurity.ExtendedMoteMaker:SearchlightEffect");
             }
         }
 
@@ -58,26 +31,19 @@ namespace Multiplayer.Compat
             {
                 var type = AccessTools.TypeByName("VFESecurity.CompLongRangeArtillery");
 
-                selectedCompsProperty = AccessTools.Property(type, "SelectedComps");
-                targetedTileField = AccessTools.FieldRefAccess<GlobalTargetInfo>(type, "targetedTile");
-                resetWarmupTicksMethod = AccessTools.DeclaredMethod(type, "ResetWarmupTicks");
-
                 MP.RegisterSyncMethod(type, "ResetForcedTarget");
-                MP.RegisterSyncMethod(typeof(VFESecurity), nameof(SetTargetedTile));
 
-                MpCompat.harmony.Patch(AccessTools.Method(type, "SetTargetedTile"), new HarmonyMethod(typeof(VFESecurity), nameof(Prefix)));
+                var method = AccessTools.DeclaredMethod(type, "SetTargetedTile");
+                MP.RegisterSyncMethod(method).SetContext(SyncContext.MapSelected);
+                MpCompat.harmony.Patch(method, prefix: new HarmonyMethod(typeof(VFESecurity), nameof(PreSetTargetedTile)));
             }
 
             // RNG fix
             {
                 var methods = new[]
                 {
-                    // ArtilleryComp:TryResolveArtilleryCount is called by ArtilleryComp:CompTick
-                    "VFESecurity.ArtilleryComp:BombardmentTick",
-                    "VFESecurity.ArtilleryComp:TryStartBombardment",
                     "VFESecurity.Building_Shield:Notify_EnergyDepleted",
                     "VFESecurity.Building_Shield:Draw",
-                    "VFESecurity.CompLongRangeArtillery:CompTick",
                 };
 
                 PatchingUtilities.PatchPushPopRand(AccessTools.Method("VFESecurity.Building_Shield:AbsorbDamage", new[] { typeof(float), typeof(DamageDef), typeof(float) }));
@@ -85,28 +51,12 @@ namespace Multiplayer.Compat
             }
         }
 
-        private static bool Prefix(GlobalTargetInfo t)
+        // Will run before the original method gets synced
+        private static void PreSetTargetedTile()
         {
-            if (!MP.IsInMultiplayer)
-                return true;
-
-            CameraJumper.TryHideWorld();
-            var selected = ((IEnumerable)selectedCompsProperty.GetValue(null)).Cast<ThingComp>().ToList();
-            SetTargetedTile(t.WorldObject, selected);
-            return false;
-        }
-
-        private static void SetTargetedTile(WorldObject worldObject, List<ThingComp> elements)
-        {
-            foreach (var artillery in elements)
-            {
-                var turret = (Building_TurretGun)artillery.parent;
-                turret.ResetForcedTarget();
-                turret.ResetCurrentTarget();
-                targetedTileField(artillery) = new GlobalTargetInfo(worldObject);
-                SoundDefOf.TurretAcquireTarget.PlayOneShot(new TargetInfo(artillery.parent.Position, artillery.parent.Map, false));
-                resetWarmupTicksMethod.Invoke(artillery, null);
-            }
+            // Close now, as waiting for the method to be synced may take a while depending on ticks behind
+            if (!MP.IsExecutingSyncCommand)
+                CameraJumper.TryHideWorld();
         }
     }
 }

--- a/Source/Mods/VanillaPsycastsExpanded.cs
+++ b/Source/Mods/VanillaPsycastsExpanded.cs
@@ -123,6 +123,12 @@ namespace Multiplayer.Compat
                 MpCompat.RegisterLambdaDelegate("VanillaPsycastsExpanded.Ability_GuardianSkipBarrier", "GetGizmo", 0);
             }
 
+            // Current map usage
+            {
+                // Already patched on GitHub, this patch should become redundant the next time the mod updates
+                PatchingUtilities.ReplaceCurrentMapUsage("VanillaPsycastsExpanded.Harmonist.HediffComp_MindControl:CompPostPostRemoved");
+            }
+
             LongEventHandler.ExecuteWhenFinished(LatePatch);
         }
 

--- a/Source/Mods/VanillaRacesPhytokin.cs
+++ b/Source/Mods/VanillaRacesPhytokin.cs
@@ -23,9 +23,6 @@ namespace Multiplayer.Compat
             MP.RegisterSyncMethod(type, "Pump").SetDebugOnly(); // Also called while ticking
             // Set next pump time
             MpCompat.RegisterLambdaDelegate(type, "CompGetGizmosExtra", 1).SetDebugOnly();
-            // Fix the mod using Find.CurrentMap instead of parent.Map
-            // Can be safely removed it the following PR is accepted: https://github.com/Vanilla-Expanded/VanillaRacesExpanded-Phytokin/pull/2
-            PatchingUtilities.ReplaceCurrentMapUsage(type, "CompTick");
         }
     }
 }

--- a/Source/Mods/VanillaRacesSanguophage.cs
+++ b/Source/Mods/VanillaRacesSanguophage.cs
@@ -13,15 +13,11 @@ namespace Multiplayer.Compat
     [MpCompatFor("vanillaracesexpanded.sanguophage")]
     public class VanillaRacesSanguophage
     {
-        private static GameConditionDef bloodmoonConditionDef;
-
         private static Type singleUseAbilitiesCommandType;
         private static AccessTools.FieldRef<Command, Building> singleUseAbilitiesCommandBuildingField;
 
         public VanillaRacesSanguophage(ModContentPack mod)
         {
-            LongEventHandler.ExecuteWhenFinished(LatePatch);
-
             var type = singleUseAbilitiesCommandType = AccessTools.TypeByName("VanillaRacesExpandedSanguophage.Command_SingleUseAbilities");
             singleUseAbilitiesCommandBuildingField = AccessTools.FieldRefAccess<Building>(type, "building");
             MP.RegisterSyncWorker<Command>(SyncSingleUseAbilitiesCommand, type);
@@ -34,59 +30,12 @@ namespace Multiplayer.Compat
             MpCompat.RegisterLambdaDelegate(type, "AddCarryToBatteryJobs", 0);
         }
 
-        // TODO: Remove if fixed in the mod itself (fixed by following PR: https://github.com/Vanilla-Expanded/VanillaRacesExpanded-Sanguophage/pull/1)
-        private static void LatePatch()
-        {
-            var unsafeCall = AccessTools.DeclaredPropertyGetter(typeof(Game), nameof(Game.CurrentMap));
-            var vfePatch = AccessTools.DeclaredMethod("VanillaRacesExpandedSanguophage.VanillaRacesExpandedSanguophage_GeneResourceDrainUtility_OffsetResource_Apply_Patch:DoubleHemogenLoss");
-
-            if (!PatchProcessor.GetCurrentInstructions(vfePatch).Any(ci => ci.operand is MethodInfo method && method == unsafeCall))
-            {
-                Log.Warning($"It looks like VFE patch for {nameof(GeneResourceDrainUtility)}.{nameof(GeneResourceDrainUtility.OffsetResource)} was fixed. MP compat patch can now be safely removed from the code. The patch is currently inactive.");
-                return;
-            }
-
-            bloodmoonConditionDef = (GameConditionDef)AccessTools.Field("VanillaRacesExpandedSanguophage.InternalDefOf:VRE_BloodMoonCondition")?.GetValue(null);
-            if (bloodmoonConditionDef == null)
-                Log.Error("GameConditionDef `VRE_BloodMoonCondition` not found. Double hemogen loss during blood moons will be disabled in MP.");
-
-            MpCompat.harmony.Patch(
-                vfePatch,
-                prefix: new HarmonyMethod(typeof(VanillaRacesSanguophage), nameof(PreVfeOffsetResource)));
-        }
-
         private static void SyncSingleUseAbilitiesCommand(SyncWorker sync, ref Command command)
         {
             if (sync.isWriting)
                 sync.Write(singleUseAbilitiesCommandBuildingField(command));
             else
                 command = (Command)Activator.CreateInstance(singleUseAbilitiesCommandType, sync.Read<Building>());
-        }
-
-        // TODO: Remove if fixed in the mod itself (fixed by following PR: https://github.com/Vanilla-Expanded/VanillaRacesExpanded-Sanguophage/pull/1)
-        private static bool PreVfeOffsetResource(IGeneResourceDrain drain, float amnt)
-        {
-            // The method we're patching doesn't do anything if it's positive/zero, skip executing it
-            if (amnt >= 0)
-                return false;
-
-            // Let the mod itself handle this stuff, especially if we failed getting 
-            if (!MP.IsInMultiplayer)
-                return true;
-
-            // Can't handle the blood moon, so just skip the original method and don't do anything the def for blood moon
-            if (bloodmoonConditionDef == null)
-                return false;
-
-            // Handle the extra change if the blood moon is active (and pawn/map aren't null)
-            if (drain.Pawn?.Map?.GameConditionManager.ConditionIsActive(bloodmoonConditionDef) == true)
-            {
-                var value = drain.Resource.Value;
-                drain.Resource.Value += amnt;
-                GeneResourceDrainUtility.PostResourceOffset(drain, value);
-            }
-
-            return false;
         }
     }
 }


### PR DESCRIPTION
Vanilla Furniture Expanded - Security got cleaned quite a bit. The patch itself was quite old, and a lot of the stuff it did was unnecessary.

In Vanilla Events Expanded, the option to remove map/world condition in settings got synced. This required a sync worker for `GameCondition`, it'll need to be included in MP as well.

Vanilla Events Expanded and Vanilla Psycasts Expanded now include patches to remove the current map usage.

A few other patches that were no longer needed got removed.