### PR TITLE
Fix fog motes weather overlay in ReGrowth: Core

### DIFF
--- a/Source/Mods/ReGrowthCore.cs
+++ b/Source/Mods/ReGrowthCore.cs
@@ -14,6 +14,10 @@ namespace Multiplayer.Compat
 
             // (Dev) spawn leaves
             MpCompat.RegisterLambdaMethod("ReGrowthCore.CompLeavesSpawnerBase", "CompGetGizmosExtra", 0).SetDebugOnly();
+
+            // RNG
+            // Could be fixed by clearing the cache on join, but it affects a small graphical thing (motes). Not really worth bothering with.
+            PatchingUtilities.PatchPushPopRand("ReGrowthCore.WeatherOverlay_FogMotes:TickOverlay");
         }
 
         private static void LatePatch() => PatchingUtilities.PatchPushPopRand("ReGrowthCore.DevilDust_Tornado:ThrowDevilDustPuff");


### PR DESCRIPTION
Seems to be only used in ReGrowth: Boiling, possibly more in the future.