### PR TITLE
Updated current map patcher and mods needing it

### DIFF
--- a/Source/Mods/AlphaGenes.cs
+++ b/Source/Mods/AlphaGenes.cs
@@ -24,13 +24,6 @@ namespace Multiplayer.Compat
                 MpCompat.RegisterLambdaMethod("AlphaGenes.Ability_ReactiveArmour", "GetGizmos", 0, 2);
                 MpCompat.RegisterLambdaDelegate("AlphaGenes.CompScorpionCounter", "CompGetGizmosExtra", 0).SetDebugOnly();
             }
-
-            // Current map usage
-            {
-                PatchingUtilities.ReplaceCurrentMapUsage("AlphaGenes.HediffComp_DeleteAfterTime:CompPostTick");
-                // Debug stuff, may get changed or removed.
-                PatchingUtilities.ReplaceCurrentMapUsage("AlphaGenes.CompRandomItemSpawner:CompTick");
-            }
         }
     }
 }

--- a/Source/Mods/AlphaMemes.cs
+++ b/Source/Mods/AlphaMemes.cs
@@ -1,4 +1,4 @@
-﻿using Multiplayer.Compat;
+﻿using HarmonyLib;
 using Verse;
 
 namespace Multiplayer.Compat
@@ -17,8 +17,13 @@ namespace Multiplayer.Compat
             // If not, then patching it as well should fix it
             //"AlphaMemes.GameComponent_RandomMood:GameComponentTick",
 
-            // Hediffs added in MoodOffset, can be called during alert updates (not synced)
+            // Hediffs added in MoodOffset, can be called during alert updates (not synced).
+            // Possibly causes https://github.com/rwmt/Multiplayer-Compatibility/issues/302 
             PatchingUtilities.PatchCancelMethodOnUI("AlphaMemes.Thought_Catharsis:MoodOffset");
+
+            // Current map usage
+            var type = AccessTools.TypeByName("AlphaMemes.AlphaMemesIdeo_Notify_Patches");
+            PatchingUtilities.ReplaceCurrentMapUsage(AccessTools.Inner(type, "FuneralFramework_Ideo_MemberCorpseDestroyed"), "Prefix");
         }
     }
 }

--- a/Source/Mods/RimFridge.cs
+++ b/Source/Mods/RimFridge.cs
@@ -18,7 +18,6 @@ namespace Multiplayer.Compat
 
         public RimFridgeCompat(ModContentPack mod)
         {
-
             // Several Gizmos
             {
                 MpCompat.RegisterLambdaDelegate("RimFridge.CompRefrigerator", "CompGetGizmosExtra", 1, 2, 3, 4, 5);
@@ -29,6 +28,11 @@ namespace Multiplayer.Compat
 
                 MP.RegisterSyncWorker<Dialog_Rename>(SyncFridgeName, dialogType);
                 MP.RegisterSyncMethod(dialogType, "SetName");
+            }
+
+            // Current map usage
+            {
+                PatchingUtilities.ReplaceCurrentMapUsage("RimFridge.Patch_ReachabilityUtility_CanReach:Prefix");
             }
         }
 


### PR DESCRIPTION
The mod changes:
- Removed patch from Alpha Genes (no longer needed)
- Added patch to Alpha Memes
- Added patch to RimFridge

The current map patcher had the following changes:

- It should work on any method that has any of the supported types as a parameter
- The instructions are now prepared beforehand and put into a list, instead of being created every time the current map usage is encountered
- Support for `Game.CurrentMap` (previously only `Find.CurrentMap` was supported)