### PR TITLE
Updated Simple Sidearms patch

### DIFF
--- a/Source/Mods/SimpleSidearms.cs
+++ b/Source/Mods/SimpleSidearms.cs
@@ -13,7 +13,7 @@ namespace Multiplayer.Compat
     [MpCompatFor("PeteTimesSix.SimpleSidearms")]
     public class SimpleSidearmsCompat
     {
-        static ISyncField primaryWeaponModeSyncField;
+        private static ISyncField primaryWeaponModeSyncField;
 
         public SimpleSidearmsCompat(ModContentPack mod)
         {
@@ -24,14 +24,17 @@ namespace Multiplayer.Compat
                 type = AccessTools.TypeByName("PeteTimesSix.SimpleSidearms.Utilities.WeaponAssingment");
 
                 var methods = new[] {
-                    "equipSpecificWeaponTypeFromInventory",
-                    "equipSpecificWeapon",
-                    "dropSidearm",
+                    "equipSpecificWeapon", // Called by equipSpecificWeaponFromInventory and equipSpecificWeaponTypeFromInventory
+                    "DropSidearm",
+                    // Tacticowl dual-wield support
+                    "EquipSpecificWeaponFromInventoryAsOffhand",
+                    "UnequipOffhand",
                 };
                 foreach (string method in methods) {
                     MP.RegisterSyncMethod(AccessTools.Method(type, method));
                 }
             }
+
             {
                 type = AccessTools.TypeByName("SimpleSidearms.rimworld.CompSidearmMemory");
 
@@ -45,8 +48,9 @@ namespace Multiplayer.Compat
                     "UnsetRangedWeaponDefault",
                     "UnsetMeleeWeaponPreference",
                     "UnsetUnarmedAsForced",
-                    "UnsetMeleeWeaponPreference",
                     "ForgetSidearmMemory",
+                    // Tacticowl dual wield support
+                    "InformOfAddedSidearm", // As opposed to InformOfAddedPrimary, this one can be called from a place we need to sync
                 };
                 foreach (string method in methods) {
                     MP.RegisterSyncMethod(AccessTools.Method(type, method));
@@ -55,6 +59,7 @@ namespace Multiplayer.Compat
                 // TODO: Suggest the author to encapsulate this, would simplify things so much
                 primaryWeaponModeSyncField = MP.RegisterSyncField(AccessTools.Field(type, "primaryWeaponMode"));
             }
+
             // Required for primaryWeaponMode
             {
                 type = AccessTools.TypeByName("SimpleSidearms.rimworld.Gizmo_SidearmsList");
@@ -63,24 +68,18 @@ namespace Multiplayer.Compat
                     prefix: new HarmonyMethod(typeof(SimpleSidearmsCompat), nameof(HandleInteractionPrefix)),
                     postfix: new HarmonyMethod(typeof(SimpleSidearmsCompat), nameof(HandleInteractionPostfix)));
             }
-            {
-                type = AccessTools.TypeByName("SimpleSidearms.rimworld.CompSidearmMemory");
 
-                MpCompat.harmony.Patch(AccessTools.Method(type, "GetMemoryCompForPawn"),
-                    postfix: new HarmonyMethod(typeof(SimpleSidearmsCompat), nameof(CaptureTheMemory)));
-            }
             // Used often in the Set* methods for CompSidearmMemory
             {
                 type = AccessTools.TypeByName("SimpleSidearms.rimworld.ThingDefStuffDefPair");
 
                 MP.RegisterSyncWorker<object>(SyncWorkerForThingDefStuffDefPair, type);
             }
-
         }
 
         #region ThingDefStuffDefPair
 
-        static void SyncWorkerForThingDefStuffDefPair(SyncWorker sync, ref object obj)
+        private static void SyncWorkerForThingDefStuffDefPair(SyncWorker sync, ref object obj)
         {
             var traverse = Traverse.Create(obj);
 
@@ -95,34 +94,23 @@ namespace Multiplayer.Compat
                 stuffField.SetValue(sync.Read<ThingDef>());
             }
         }
+
         #endregion
 
         #region primaryWeaponMode field watch
-        static bool watching;
 
-        // UGLY UGLY this is so UGLY! Yet... it works.
-        static void CaptureTheMemory(object __result)
-        {
-            if (watching) {
-                primaryWeaponModeSyncField.Watch(__result);
-            }
-        }
-
-        static void HandleInteractionPrefix()
+        private static void HandleInteractionPrefix(ThingComp ___pawnMemory)
         {
             if (MP.IsInMultiplayer) {
                 MP.WatchBegin();
-
-                watching = true;
+                primaryWeaponModeSyncField.Watch(___pawnMemory);
             }
         }
-        static void HandleInteractionPostfix()
-        {
-            if (MP.IsInMultiplayer) {
-                MP.WatchEnd();
 
-                watching = false;
-            }
+        private static void HandleInteractionPostfix()
+        {
+            if (MP.IsInMultiplayer)
+                MP.WatchEnd();
         }
 
         #endregion


### PR DESCRIPTION
- Removed syncing of `WeaponAssingment:equipSpecificWeaponTypeFromInventory` - all it does is calls `WeaponAssingment:equipSpecificWeapon`, which we sync anyway. And it doesn't seem to be called from a place we need to sync, unless I'm mistaken.
- Changed `dropSidearm` to `DropSidearm`
- Added syncing of `WeaponAssingment:EquipSpecificWeaponFromInventoryAsOffhand`, `WeaponAssingment:UnequipOffhand` and `CompSidearmMemory:InformOfAddedSidearm` (Tacticowl dual-wield support)
- Removed duplicate sync worker register call of `CompSidearmMemory:UnsetMeleeWeaponPreference`
- Removed the prefix to `CompSidearmMemory:GetMemoryCompForPawn`, and moved the syncing of the field to the `Gizmo_SidearmsList:handleInteraction` prefix. I'm assuming this was not the case in the past, but currently the `CompSidearmMemory` is being cached and there's no need for this workaround (unless I'm missing something). And to be honest, I think the old way this was handled would just not work right now, as `CompSidearmMemory:GetMemoryCompForPawn` is just not called between the beginning and the end of the sync watch.
- Slight changes, like adding explicit `private` to all methods/fields and small spacing changes.

I would have changed the sync worker to be faster, but the simple way of using Harmony's StructFieldRef is not an option as we can't directly reference the struct itself. Because of this, I decided to leave this as-is.