### PR TITLE
Updated compat for Vanilla Social Interactions Expanded

### DIFF
--- a/Source/Mods/VanillaSocialInteractions.cs
+++ b/Source/Mods/VanillaSocialInteractions.cs
@@ -1,4 +1,6 @@
-﻿using Verse;
+﻿using System.Collections;
+using HarmonyLib;
+using Verse;
 
 namespace Multiplayer.Compat
 {
@@ -8,7 +10,18 @@ namespace Multiplayer.Compat
     [MpCompatFor("VanillaExpanded.VanillaSocialInteractionsExpanded")]
     public class VanillaSocialInteractions
     {
-        public VanillaSocialInteractions(ModContentPack mod) =>
-            PatchingUtilities.PatchPushPopRand("VanillaSocialInteractionsExpanded.SocialInteractionsManager:GameComponentTick");
+        private static AccessTools.FieldRef<IDictionary> averageOpinionCacheField;
+
+        public VanillaSocialInteractions(ModContentPack mod)
+        {
+            // Clear cache
+            var field = AccessTools.DeclaredField("VanillaSocialInteractionsExpanded.VSIE_Utils:averageOpinionOfCache");
+            averageOpinionCacheField = AccessTools.StaticFieldRefAccess<IDictionary>(field);
+
+            MpCompat.harmony.Patch(AccessTools.DeclaredMethod(typeof(GameComponentUtility), nameof(GameComponentUtility.FinalizeInit)),
+                postfix: new HarmonyMethod(typeof(VanillaSocialInteractions), nameof(ClearCache)));
+        }
+
+        private static void ClearCache() => averageOpinionCacheField().Clear();
     }
 }


### PR DESCRIPTION
With my original compat, I've (incorrectly) assumed the issue may have been related to RNG somewhere.

The actual issue seems to be caused by cache not being cleared. At least I'm assuming this is the only one issue this mod had, I was not able to find anything else.