### PR TITLE
Cancel in interface rename, improvements, additions

### DIFF
--- a/Source/Mods/AllowTool.cs
+++ b/Source/Mods/AllowTool.cs
@@ -121,7 +121,7 @@ namespace Multiplayer.Compat
             // Recache haul urgently deterministically (currently uses Time.unscaledTime)
             {
                 // Used by DeterministicallyHandleReCaching
-                PatchingUtilities.InitCancelOnUI();
+                PatchingUtilities.InitCancelInInterface();
 
                 var type = AccessTools.TypeByName("AllowTool.HaulUrgentlyCacheHandler");
                 MpCompat.harmony.Patch(AccessTools.Method(type, "RecacheIfNeeded"),

--- a/Source/Mods/AlphaMemes.cs
+++ b/Source/Mods/AlphaMemes.cs
@@ -19,7 +19,7 @@ namespace Multiplayer.Compat
 
             // Hediffs added in MoodOffset, can be called during alert updates (not synced).
             // Possibly causes https://github.com/rwmt/Multiplayer-Compatibility/issues/302 
-            PatchingUtilities.PatchCancelMethodOnUI("AlphaMemes.Thought_Catharsis:MoodOffset");
+            PatchingUtilities.PatchCancelInInterface("AlphaMemes.Thought_Catharsis:MoodOffset");
 
             // Current map usage
             var type = AccessTools.TypeByName("AlphaMemes.AlphaMemesIdeo_Notify_Patches");

--- a/Source/Mods/LightsOut.cs
+++ b/Source/Mods/LightsOut.cs
@@ -12,22 +12,22 @@ namespace Multiplayer.Compat
     [MpCompatFor("juanlopez2008.LightsOut")]
     internal class LightsOut
     {
-        private static Type commandType;
-        private static MethodInfo parentCompGetter;
-
         public LightsOut(ModContentPack mod)
         {
-            commandType = AccessTools.TypeByName("LightsOut.Gizmos.KeepOnGizmo");
-            parentCompGetter = AccessTools.PropertyGetter(commandType, "ParentComp");
+            // Gizmos
+            {
+                MP.RegisterSyncMethod(AccessTools.PropertySetter("LightsOut.ThingComps.KeepOnComp:KeepOn"));
+            }
 
-            MP.RegisterSyncMethod(commandType, "ToggleAction");
-            MP.RegisterSyncWorker<Command_Toggle>(SyncToggleCommand, commandType);
-        }
-
-        private static void SyncToggleCommand(SyncWorker sync, ref Command_Toggle command)
-        {
-            if (sync.isWriting) sync.Write(parentCompGetter.Invoke(command, Array.Empty<object>()) as ThingComp);
-            else command = Activator.CreateInstance(commandType, sync.Read<ThingComp>()) as Command_Toggle;
+            // Patched sync methods
+            {
+                PatchingUtilities.PatchCancelInInterface(
+                    // From the patches we care for, PatchTableOff affects gene extractor and subcore scanner
+                    "LightsOut.Common.TablesHelper:PatchTableOff",
+                    // PatchTableOn doesn't look like it needs a patch, as it's not used on any sync methods
+                    "LightsOut.Patches.ModCompatibility.Biotech.PatchGeneAssembly:OnStart",
+                    "LightsOut.Patches.ModCompatibility.Biotech.PatchWasteAtomiser:UpdateWorking");
+            }
         }
     }
 }

--- a/Source/Mods/SRTSExpanded.cs
+++ b/Source/Mods/SRTSExpanded.cs
@@ -53,6 +53,7 @@ namespace Multiplayer.Compat
             var tryLaunch = AccessTools.Method(type, "TryLaunch");
             tryLaunchMethod = MethodInvoker.GetHandler(tryLaunch);
 
+            PatchingUtilities.InitCancelInInterface();
             MpCompat.harmony.Patch(tryLaunch, prefix: new HarmonyMethod(typeof(SRTSExpanded), nameof(PreTryLaunch)));
             MP.RegisterSyncMethod(typeof(SRTSExpanded), nameof(SyncedLaunch)).ExposeParameter(2);
 
@@ -79,7 +80,7 @@ namespace Multiplayer.Compat
         private static bool PreTryLaunch(ThingComp __instance, int destinationTile, TransportPodsArrivalAction arrivalAction, Caravan cafr = null)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || MP.IsExecutingSyncCommand)
+            if (PatchingUtilities.ShouldCancel)
                 return true;
 
             var caravanFieldValue = caravanField(__instance);
@@ -138,7 +139,7 @@ namespace Multiplayer.Compat
         private static bool PreAddPawns(ThingComp __instance, List<Pawn> ___tmpAllowedPawns)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || MP.IsExecutingSyncCommand)
+            if (PatchingUtilities.ShouldCancel)
                 return true;
 
             SyncedAddPawns(__instance, ___tmpAllowedPawns);

--- a/Source/Mods/SimpleSidearms.cs
+++ b/Source/Mods/SimpleSidearms.cs
@@ -75,6 +75,15 @@ namespace Multiplayer.Compat
 
                 MP.RegisterSyncWorker<object>(SyncWorkerForThingDefStuffDefPair, type);
             }
+            
+            // Patched sync methods
+            {
+                // When undrafted, the pawns will remove their temporary forced weapon.
+                // Could cause issues when drafting pawns, as they'll be considered undrafted when the postfix runs.
+                PatchingUtilities.PatchCancelInInterface("PeteTimesSix.SimpleSidearms.Intercepts.Pawn_DraftController_Drafted_Setter_Postfix:DraftedSetter");
+                // When dropping a weapon, it'll cause the pawn to about preferences towards them.
+                PatchingUtilities.PatchCancelInInterface("PeteTimesSix.SimpleSidearms.Intercepts.ITab_Pawn_Gear_InterfaceDrop_Prefix:InterfaceDrop");
+            }
         }
 
         #region ThingDefStuffDefPair

--- a/Source/Mods/SmartMedicine.cs
+++ b/Source/Mods/SmartMedicine.cs
@@ -81,6 +81,15 @@ namespace Multiplayer.Compat
                     getSmartMedicinePriorityCareDictionary = MethodInvoker.GetHandler(AccessTools.Method(type, "Get"));
                 }
             }
+
+            // Patched sync methods
+            {
+                // When ordering a pawn to drop something, it'll try to stop them from stocking up on it.
+                // Will cause desyncs if this happened to be something they were stocking up
+                // if the pawn decides to unload the things they were stocking up on.
+                // Used for both vanilla and RPG style inventory InterfaceDrop method.
+                PatchingUtilities.PatchCancelInInterface("SmartMedicine.InterfaceDrop_Patch:Postfix");
+            }
         }
 
         private static bool PreSetStockCount(Pawn pawn, ThingDef thingDef, int count)

--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -120,7 +120,7 @@ namespace Multiplayer.Compat
 
         // Hediffs added in MoodOffset, can be called during alert updates (not synced)
         private static void PatchVanillaCookingExpanded()
-            => PatchingUtilities.PatchCancelMethodOnUI("VanillaCookingExpanded.Thought_Hediff:MoodOffset");
+            => PatchingUtilities.PatchCancelInInterface("VanillaCookingExpanded.Thought_Hediff:MoodOffset");
 
         private static void PatchVanillaFactionMechanoids()
         {
@@ -523,6 +523,10 @@ namespace Multiplayer.Compat
             MpCompat.harmony.Patch(AccessTools.DeclaredMethod(type, "DoWindowContents"),
                 transpiler: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(Dialog_ChooseGraphic_ReplaceSelectionButton)));
             MP.RegisterSyncMethod(typeof(VanillaExpandedFramework), nameof(Dialog_ChooseGraphic_SyncChange));
+
+            type = AccessTools.TypeByName("VanillaFurnitureExpanded.CompGlowerExtended");
+            type = AccessTools.Inner(type, "CompGlower_SetGlowColorInternal_Patch");
+            PatchingUtilities.PatchCancelInInterface(AccessTools.DeclaredMethod(type, "Postfix"));
         }
 
         private static void SyncSetStoneTypeCommand(SyncWorker sync, ref Command obj)
@@ -668,6 +672,9 @@ namespace Multiplayer.Compat
             MpCompat.RegisterLambdaDelegate(type, "GetAttackGizmos_Postfix", 4); // Interrupt Attack
 
             MpCompat.RegisterLambdaDelegate("MVCF.Features.Feature_RangedAnimals", "Pawn_GetGizmos_Postfix", 0); // Also interrupt Attack
+
+            // Changes the verb, so when called before syncing (especially if the original method is canceled by another mod) - will cause issues.
+            PatchingUtilities.PatchCancelInInterfaceSetResultToTrue("MVCF.Features.PatchSets.PatchSet_Base:Prefix_OrderForceTarget");
         }
 
         // Initialize the VerbManager early, we expect it to exist on every player.

--- a/Source/Mods/VanillaFactionsPirates.cs
+++ b/Source/Mods/VanillaFactionsPirates.cs
@@ -50,6 +50,7 @@ namespace Multiplayer.Compat
                 // The code using the ability returns true, and we need to make sure it happens because
                 // as far as I understand, sync method on non-void methods returns default value (which
                 // would be false for bool)
+                PatchingUtilities.InitCancelInInterface();
                 MP.RegisterSyncMethod(typeof(VanillaFactionsPirates), nameof(SyncedShieldDetonation));
                 MpCompat.harmony.Patch(AccessTools.Method("VFEPirates.Verb_ShieldDetonation:TryCastShot"),
                     prefix: new HarmonyMethod(typeof(VanillaFactionsPirates), nameof(PreShieldDetonation)));
@@ -245,7 +246,7 @@ namespace Multiplayer.Compat
 
         private static bool PreShieldDetonation(Verb __instance, ref bool __result)
         {
-            if (!MP.IsInMultiplayer || MP.IsExecutingSyncCommand)
+            if (PatchingUtilities.ShouldCancel)
                 return true;
 
             // We need to sync as ThingComp, as MP only supports 2 comps - CompEquippable and CompReloadable

--- a/Source/Mods/VanillaFurnitureExpandedSecurity.cs
+++ b/Source/Mods/VanillaFurnitureExpandedSecurity.cs
@@ -23,6 +23,15 @@ namespace Multiplayer.Compat
                 // Motes
                 PatchingUtilities.PatchPushPopRand("VFESecurity.ExtendedMoteMaker:SearchlightEffect");
             }
+
+            // Patched sync methods
+            {
+                // When picking a new target the old one is (supposed to be) cleared.
+                // Could cause issues if the player is behind on ticks.
+                var type = AccessTools.TypeByName("VFESecurity.Patch_Building_TurretGun");
+                type = AccessTools.Inner(type, "OrderAttack");
+                PatchingUtilities.PatchCancelInInterface(AccessTools.DeclaredMethod(type, "Postfix"));
+            }
         }
 
         private static void LateSyncMethods()

--- a/Source/Mods/VanillaHairExpanded.cs
+++ b/Source/Mods/VanillaHairExpanded.cs
@@ -50,6 +50,7 @@ namespace Multiplayer.Compat
             beardDefField = AccessTools.Field(type, "beardDef");
             hairColourField = AccessTools.Field(type, "hairColour");
 
+            PatchingUtilities.InitCancelInInterface();
             MpCompat.harmony.Patch(AccessTools.Method(typeof(WindowStack), nameof(WindowStack.TryRemove), new[] { typeof(Window), typeof(bool) }),
                 prefix: new HarmonyMethod(typeof(VanillaHairExpanded), nameof(PreTryRemoveWindow)));
 
@@ -76,7 +77,7 @@ namespace Multiplayer.Compat
         private static bool PreTryRemoveWindow(Window window)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || MP.IsExecutingSyncCommand || window.GetType() != changeHairstyleDialogType)
+            if (PatchingUtilities.ShouldCancel || window.GetType() != changeHairstyleDialogType)
                 return true;
 
             SyncedTryRemoveWindow();

--- a/Source/Mods/VanillaIdeologyMemes.cs
+++ b/Source/Mods/VanillaIdeologyMemes.cs
@@ -40,7 +40,14 @@ namespace Multiplayer.Compat
             // Gamplay logic during UI code
             {
                 // Hediffs added in MoodOffset, can be called during alert updates (not synced)
-                PatchingUtilities.PatchCancelMethodOnUI("VanillaMemesExpanded.Thought_DisableFirstDefeatThought:MoodOffset");
+                PatchingUtilities.PatchCancelInInterface("VanillaMemesExpanded.Thought_DisableFirstDefeatThought:MoodOffset");
+            }
+
+            // Patched sync methods
+            {
+                // Resets timer for the last time a settlement was abandoned. If called before syncing it
+                // will cause pawns to temporarily lose specific thoughts related to them for the player syncing.
+                PatchingUtilities.PatchCancelInInterface("VanillaMemesExpanded.VanillaMemesExpanded_SettlementAbandonUtility_Abandon_Patch:SetAbandonedTimeToZero");
             }
         }
     }

--- a/Source/Mods/VanillaRacesHussar.cs
+++ b/Source/Mods/VanillaRacesHussar.cs
@@ -1,0 +1,17 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Vanilla Races Expanded - Hussar by Oskar Potocki, xrushha, Taranchuk, Sarg</summary>
+    /// <see href="https://github.com/Vanilla-Expanded/VanillaRacesExpanded-Hussar"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2893586390"/>
+    [MpCompatFor("vanillaracesexpanded.hussar")]
+    public class VanillaRacesHussar
+    {
+        public VanillaRacesHussar(ModContentPack mod)
+        {
+            // Trigger queued mental break when undrafted, which will happen right after clicking but before it's synced.
+            PatchingUtilities.PatchCancelInInterface("VREHussars.Pawn_DraftController_Drafted_Patch:Postfix");
+        }
+    }
+}

--- a/Source/Mods/VanillaTraitsExpanded.cs
+++ b/Source/Mods/VanillaTraitsExpanded.cs
@@ -36,12 +36,9 @@ namespace Multiplayer.Compat
                 // On top of that, it also adds the current job to the list of forced jobs for absent minded pawns.
                 // This can cause issues when the mod operates and does stuff based on those, but they are in different state for all players.
                 // The issue is that a sync method catches this call, but all prefixes/postfixes/etc. still run.
-                MpCompat.harmony.Patch(AccessTools.DeclaredMethod("VanillaTraitsExpanded.TryTakeOrderedJob_Patch:Postfix"),
-                    prefix: new HarmonyMethod(typeof(VanillaTraitsExpanded), nameof(CancelUnlessSynced)));
+                PatchingUtilities.PatchCancelInInterface(AccessTools.DeclaredMethod("VanillaTraitsExpanded.TryTakeOrderedJob_Patch:Postfix"));
             }
         }
-
-        private static bool CancelUnlessSynced() => !MP.IsInMultiplayer || MP.IsExecutingSyncCommand;
 
         private static void ClearCache() => mapPawnsAnimalListField().Clear();
     }

--- a/Source_Referenced/VanillaFactionsEmpire.cs
+++ b/Source_Referenced/VanillaFactionsEmpire.cs
@@ -8,6 +8,7 @@ using RimWorld.Planet;
 using Verse;
 using Verse.AI.Group;
 using VFEEmpire;
+using VFEEmpire.HarmonyPatches;
 
 namespace Multiplayer.Compat
 {
@@ -120,6 +121,13 @@ namespace Multiplayer.Compat
                 // Grant all honors
                 MpCompat.RegisterLambdaMethod(typeof(HonorsTracker), nameof(HonorsTracker.GetGizmos), 4).SetDebugOnly();
                 MP.RegisterSyncWorker<HonorsTracker>(SyncHonorsTracker);
+            }
+
+            // Patched sync methods
+            {
+                // Basically when called, it removes the pawns from list with pawns with titles, and if they still have them - they get re-added.
+                // Causes the order to change, which could cause issues before the method is synced.
+                PatchingUtilities.PatchCancelInInterface(AccessTools.DeclaredMethod(typeof(ColonistTitleCache.RoyaltyTracker), nameof(ColonistTitleCache.RoyaltyTracker.Postfix)));
             }
         }
 


### PR DESCRIPTION
- Cancel on UI got renamed to Cancel in Interface (matching MP itself).
- The getter will now target MP's `InInterface` getter instead of a getter from a harmony patch.
- Some patches now use `PatchingUtilities.ShouldCancel` to check if they should run the original method.
- Many methods that would run before/after a sync method are now cancelled during interface calls (still allowed during ticking/sync methods/etc.).
- Added compat for Vanilla Races Expanded - Hussar, as it could cause issues due to patched sync methods.
- As I've been adding stuff to LightsOut, the old patch was simplified as well. I'm not splitting it into 2 PRs, as it would most likely create merge conflicts.