### PR TITLE
Fixed desyncs/crashes due to reverse condition

### DIFF
--- a/Source/Mods/SRTSExpanded.cs
+++ b/Source/Mods/SRTSExpanded.cs
@@ -80,7 +80,7 @@ namespace Multiplayer.Compat
         private static bool PreTryLaunch(ThingComp __instance, int destinationTile, TransportPodsArrivalAction arrivalAction, Caravan cafr = null)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || PatchingUtilities.ShouldCancel)
+            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel)
                 return true;
 
             var caravanFieldValue = caravanField(__instance);
@@ -139,7 +139,7 @@ namespace Multiplayer.Compat
         private static bool PreAddPawns(ThingComp __instance, List<Pawn> ___tmpAllowedPawns)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || PatchingUtilities.ShouldCancel)
+            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel)
                 return true;
 
             SyncedAddPawns(__instance, ___tmpAllowedPawns);

--- a/Source/Mods/VanillaFactionsPirates.cs
+++ b/Source/Mods/VanillaFactionsPirates.cs
@@ -246,7 +246,7 @@ namespace Multiplayer.Compat
 
         private static bool PreShieldDetonation(Verb __instance, ref bool __result)
         {
-            if (!MP.IsInMultiplayer || PatchingUtilities.ShouldCancel)
+            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel)
                 return true;
 
             // We need to sync as ThingComp, as MP only supports 2 comps - CompEquippable and CompReloadable

--- a/Source/Mods/VanillaHairExpanded.cs
+++ b/Source/Mods/VanillaHairExpanded.cs
@@ -77,7 +77,7 @@ namespace Multiplayer.Compat
         private static bool PreTryRemoveWindow(Window window)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || PatchingUtilities.ShouldCancel || window.GetType() != changeHairstyleDialogType)
+            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel || window.GetType() != changeHairstyleDialogType)
                 return true;
 
             SyncedTryRemoveWindow();


### PR DESCRIPTION
Seems that in the end, I forgot to put the `!` symbol. Most likely happened as at one point, `PatchingUtilities.ShouldCancel` had the opposite result (so I most likely forgot to update it once I change it).