### PR TITLE
General changes to old code, removal of obsolete code

### DIFF
--- a/Source/Mods/BiotechExpansionMythic.cs
+++ b/Source/Mods/BiotechExpansionMythic.cs
@@ -20,8 +20,6 @@ namespace Multiplayer.Compat
 
         public BiotechExpansionMythic(ModContentPack mod)
         {
-            MpSyncWorkers.Requires<IGeneResourceDrain>();
-
             var type = AccessTools.TypeByName("BTE_MY.CompCreateReveredMote");
             MP.RegisterSyncMethod(type, "GetMeditationSpots"); // Scan for meditation spots
             MP.RegisterSyncMethod(type, "AddProgress").SetDebugOnly(); // (Dev) add 100% progress (also called during ticking)

--- a/Source/Mods/SRTSExpanded.cs
+++ b/Source/Mods/SRTSExpanded.cs
@@ -83,7 +83,7 @@ namespace Multiplayer.Compat
         private static bool PreTryLaunch(ThingComp __instance, int destinationTile, TransportPodsArrivalAction arrivalAction, Caravan cafr = null)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel)
+            if (!PatchingUtilities.ShouldCancel)
                 return true;
 
             var caravanFieldValue = caravanField(__instance);
@@ -142,7 +142,7 @@ namespace Multiplayer.Compat
         private static bool PreAddPawns(ThingComp __instance, List<Pawn> ___tmpAllowedPawns)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel)
+            if (!PatchingUtilities.ShouldCancel)
                 return true;
 
             SyncedAddPawns(__instance, ___tmpAllowedPawns);

--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -8,6 +8,7 @@ using System.Runtime.CompilerServices;
 using HarmonyLib;
 using Multiplayer.API;
 using RimWorld;
+using RimWorld.Planet;
 using UnityEngine;
 using Verse;
 
@@ -284,7 +285,8 @@ namespace Multiplayer.Compat
             abilityInitMethod = MethodInvoker.GetHandler(AccessTools.Method(type, "Init"));
             abilityHolderField = AccessTools.FieldRefAccess<Thing>(type, "holder");
             abilityPawnField = AccessTools.FieldRefAccess<Pawn>(type, "pawn");
-            MP.RegisterSyncMethod(type, "CreateCastJob");
+            // There's another method taking LocalTargetInfo. Harmony grabs the one we need, but just in case specify the types to avoid ambiguity.
+            MP.RegisterSyncMethod(type, "CreateCastJob", new SyncType[] { typeof(GlobalTargetInfo[]) });
             MP.RegisterSyncWorker<ITargetingSource>(SyncVEFAbility, type, true);
             abilityAutoCastField = MP.RegisterSyncField(type, "autoCast");
             MpCompat.harmony.Patch(AccessTools.DeclaredMethod(type, "DoAction"),

--- a/Source/Mods/VanillaFactionsPirates.cs
+++ b/Source/Mods/VanillaFactionsPirates.cs
@@ -246,7 +246,7 @@ namespace Multiplayer.Compat
 
         private static bool PreShieldDetonation(Verb __instance, ref bool __result)
         {
-            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel)
+            if (!PatchingUtilities.ShouldCancel)
                 return true;
 
             // We need to sync as ThingComp, as MP only supports 2 comps - CompEquippable and CompReloadable

--- a/Source/Mods/VanillaHairExpanded.cs
+++ b/Source/Mods/VanillaHairExpanded.cs
@@ -77,7 +77,7 @@ namespace Multiplayer.Compat
         private static bool PreTryRemoveWindow(Window window)
         {
             // Let the method run only if it's synced call
-            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel || window.GetType() != changeHairstyleDialogType)
+            if (!PatchingUtilities.ShouldCancel || window.GetType() != changeHairstyleDialogType)
                 return true;
 
             SyncedTryRemoveWindow();

--- a/Source/Mods/VanillaPsycastsExpanded.cs
+++ b/Source/Mods/VanillaPsycastsExpanded.cs
@@ -123,12 +123,6 @@ namespace Multiplayer.Compat
                 MpCompat.RegisterLambdaDelegate("VanillaPsycastsExpanded.Ability_GuardianSkipBarrier", "GetGizmo", 0);
             }
 
-            // Current map usage
-            {
-                // Already patched on GitHub, this patch should become redundant the next time the mod updates
-                PatchingUtilities.ReplaceCurrentMapUsage("VanillaPsycastsExpanded.Harmonist.HediffComp_MindControl:CompPostPostRemoved");
-            }
-
             LongEventHandler.ExecuteWhenFinished(LatePatch);
         }
 

--- a/Source/MpCompatLoader.cs
+++ b/Source/MpCompatLoader.cs
@@ -17,6 +17,8 @@ namespace Multiplayer.Compat
 
             foreach (var asm in content.assemblies.loadedAssemblies)
                 InitCompatInAsm(asm);
+
+            ClearCaches();
         }
         
         static void LoadConditional(ModContentPack content)
@@ -55,13 +57,6 @@ namespace Multiplayer.Compat
 
             var loadedAsm = AppDomain.CurrentDomain.Load(stream.ToArray());
             content.assemblies.loadedAssemblies.Add(loadedAsm);
-            // As we're adding the new assembly, the classes added by it aren't included by the MP GenTypes AllSubclasses/AllSubclassesNonAbstract optimization
-            // GenTypes.ClearCache() won't work, as MP isn't doing anything when it's called
-            var mpType = AccessTools.TypeByName("Multiplayer.Client.Util.TypeCache") ?? AccessTools.TypeByName("Multiplayer.Client.Multiplayer");
-            ((IDictionary)AccessTools.Field(mpType, "subClasses").GetValue(null)).Clear();
-            ((IDictionary)AccessTools.Field(mpType, "subClassesNonAbstract").GetValue(null)).Clear();
-            ((IDictionary)AccessTools.Field(mpType, "implementations").GetValue(null)).Clear();
-            AccessTools.Method(mpType, "CacheTypeHierarchy").Invoke(null, Array.Empty<object>());
         }
 
         static void InitCompatInAsm(Assembly asm)
@@ -86,6 +81,25 @@ namespace Multiplayer.Compat
                     Log.Error($"MPCompat :: Exception loading {action.mod.PackageId}: {e.InnerException ?? e}");
                 }
             }
+        }
+
+        static void ClearCaches()
+        {
+            // Clear the GenTypes cache first, as MP will use it to create its own cache (built through GenTypes.AllTypes call if null)
+            GenTypes.ClearCache();
+
+            // As we're adding the new assembly, the classes added by it aren't included by the MP GenTypes AllSubclasses/AllSubclassesNonAbstract optimization
+            // GenTypes.ClearCache() on its own won't work, as MP isn't doing anything when it's called.
+            var mpType = AccessTools.TypeByName("Multiplayer.Client.Util.TypeCache") ?? AccessTools.TypeByName("Multiplayer.Client.Multiplayer");
+            ((IDictionary)AccessTools.Field(mpType, "subClasses").GetValue(null)).Clear();
+            ((IDictionary)AccessTools.Field(mpType, "subClassesNonAbstract").GetValue(null)).Clear();
+            ((IDictionary)AccessTools.Field(mpType, "implementations").GetValue(null)).Clear();
+            AccessTools.Method(mpType, "CacheTypeHierarchy").Invoke(null, Array.Empty<object>());
+
+            // Clear/re-init the list of ISyncSimple implementations.
+            AccessTools.Method("Multiplayer.Client.ImplSerialization:Init").Invoke(null, Array.Empty<object>());
+            // Clear/re-init the localDefInfos dictionary so it contains the classes added from referenced assembly.
+            AccessTools.Method("Multiplayer.Client.MultiplayerData:CollectDefInfos").Invoke(null, Array.Empty<object>());
         }
     }
 }

--- a/Source/MpSyncWorkers.cs
+++ b/Source/MpSyncWorkers.cs
@@ -20,11 +20,7 @@ namespace Multiplayer.Compat
                 return;
             }
 
-            if (type == typeof(IGeneResourceDrain))
-                MP.RegisterSyncWorker<IGeneResourceDrain>(SyncIGeneResourceDrain);
-            else if (type == typeof(LordJob))
-                MP.RegisterSyncWorker<LordJob>(SyncLordJob, isImplicit: true);
-            else if (type == typeof(ThingDefCount))
+            if (type == typeof(ThingDefCount))
                 MP.RegisterSyncWorker<ThingDefCount>(SyncThingDefCount);
             else if (type == typeof(GameCondition))
                 MP.RegisterSyncWorker<GameCondition>(SyncGameCondition, isImplicit: true);
@@ -32,27 +28,6 @@ namespace Multiplayer.Compat
                 MP.RegisterSyncWorker<SocialCardUtility.CachedSocialTabEntry>(SyncCachedSocialTabEntry);
             else
                 Log.Error($"Trying to register SyncWorker of type {type}, but it's not supported.\n{new StackTrace(1)}");
-        }
-
-        private static void SyncIGeneResourceDrain(SyncWorker sync, ref IGeneResourceDrain resourceDrain)
-        {
-            if (sync.isWriting)
-            {
-                if (resourceDrain is Gene gene)
-                    sync.Write(gene);
-                else
-                    throw new Exception($"Unsupported {nameof(IGeneResourceDrain)} type: {resourceDrain.GetType()}");
-            }
-            else
-                resourceDrain = sync.Read<Gene>() as IGeneResourceDrain;
-        }
-
-        private static void SyncLordJob(SyncWorker sync, ref LordJob job)
-        {
-            if (sync.isWriting)
-                sync.Write(job.lord);
-            else
-                job = sync.Read<Lord>()?.LordJob;
         }
 
         private static void SyncThingDefCount(SyncWorker sync, ref ThingDefCount thingDefCount)

--- a/Source_Referenced/VanillaFactionsEmpire.cs
+++ b/Source_Referenced/VanillaFactionsEmpire.cs
@@ -22,15 +22,6 @@ namespace Multiplayer.Compat
 
         public VanillaFactionsEmpire(ModContentPack mod)
         {
-            MpSyncWorkers.Requires<LordJob>();
-
-            // TODO: test following
-            // VFEEmpire.HarmonyPatches.Patch_AddHumanlikeOrders.<>c__DisplayClass0_1:<Postfix>b__4 - TryTakeOrderedJob (discard poisoned meal)
-            // There doesn't seem to be a way to force a pawn to poison a meal, or spawn visitors with hidden deserters who could possibly cause that.
-            // Having this occur naturally is taking a bit too long, so I'm leaving this note here in case it's discovered that it causes issues.
-            // Important note is that it should be synced, as the method only calls Pawn_JobTracker.TryTakeOrderedJob, which is synced through MP.
-            // However, there's some situations where that is not the case.
-
             // Rituals
             {
                 // Art exhibit


### PR DESCRIPTION
The following were changed:
- Changed MpCompatLoader to clear caches at the end of `Load` instead of `LoadConditional` - current implementation caused some issues for me recently, and `LoadConditional` could (in theory in the future) end up being called multiple times
- Added `GenTypes.ClearCache()` for MpCompatLoader cache loading before the caches are cleared, as MP will use `GenTypes.AllTypes` to get a list of all the types
- Added a call to re-init `ISyncSimple` and `localDefInfos` cache in MpCompatLoader, as (with the upcoming API changes) they will be missing any `ISyncSimple` classes from Referenced .dll
- Changed `!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel` condition back to `!PatchingUtilities.ShouldCancel` - #348 was not needed as #349 fixed it
- Changed sync method call to `VFECore.Abilities.Ability:CreateCastJob` to specify the parameters, avoiding ambiguity due to 2 methods sharing the same name
- Removed sync workers for IGeneResourceDrain and LordJob (included in MP)
- Removed current map usage patch for Vanilla Psycasts Expanded (fixed in original mod)
- Removed flickering thoughts patch for Vanilla Races Expanded - Android (no longer needed, the way mod handles problematic code changed)
- Removed a TODO from VFE-Empire, as I've finally tested the interaction it was referring to and it works fine