### PR TITLE
Added compat for VPE Skipdoor Pathing

### DIFF
--- a/Source/Mods/VPESkipdoorPathing.cs
+++ b/Source/Mods/VPESkipdoorPathing.cs
@@ -1,0 +1,18 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>VPE Skipdoor Pathing by V337</summary>
+    /// <remarks>You should probably use Better VPE Skipdoor Pathing instead, as it has less issues: <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=3011764218"/></remarks>
+    /// <see href="https://github.com/Veritas-99/VPE-Skipdoor-Pathing"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2995157602"/>
+    [MpCompatFor("v337.VPESkipdoorPathing")]
+    public class VPESkipdoorPathing
+    {
+        public VPESkipdoorPathing(ModContentPack mod)
+        {
+            // Toggle use while drafted gizmo
+            MpCompat.RegisterLambdaMethod("VPESkipdoorPathing.CompSkipdoorPathing", nameof(ThingComp.CompGetGizmosExtra), 1);
+        }
+    }
+}


### PR DESCRIPTION
You should probably use Better VPE Skipdoor Pathing, as it has less issues. I've originally made the compat shortly before it was released, but then forgot about this compat due to how much better it was compared to this one.