### PR TITLE
Changed method synced for VFE abilities casting

### DIFF
--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -261,9 +261,6 @@ namespace Multiplayer.Compat
         private static AccessTools.FieldRef<object, Thing> abilityHolderField;
         private static AccessTools.FieldRef<object, Pawn> abilityPawnField;
         private static ISyncField abilityAutoCastField;
-        
-        // AbilityDef
-        private static AccessTools.FieldRef<Def, int> abilityDefTargetCountField;
 
         private static void PatchAbilities()
         {
@@ -296,9 +293,6 @@ namespace Multiplayer.Compat
             type = AccessTools.TypeByName("VFECore.CompShieldField");
             MpCompat.RegisterLambdaMethod(type, nameof(ThingComp.CompGetWornGizmosExtra), 0);
             MpCompat.RegisterLambdaMethod(type, "GetGizmos", 0, 2);
-
-            type = AccessTools.TypeByName("VFECore.Abilities.AbilityDef");
-            abilityDefTargetCountField = AccessTools.FieldRefAccess<int>(type, "targetCount");
         }
 
         private static void SyncVEFAbility(SyncWorker sync, ref ITargetingSource source)

--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -286,14 +286,12 @@ namespace Multiplayer.Compat
             abilityHolderField = AccessTools.FieldRefAccess<Thing>(type, "holder");
             abilityPawnField = AccessTools.FieldRefAccess<Pawn>(type, "pawn");
             // There's another method taking LocalTargetInfo. Harmony grabs the one we need, but just in case specify the types to avoid ambiguity.
-            MP.RegisterSyncMethod(type, "CreateCastJob", new SyncType[] { typeof(GlobalTargetInfo[]) });
+            MP.RegisterSyncMethod(type, "StartAbilityJob", new SyncType[] { typeof(GlobalTargetInfo[]) });
             MP.RegisterSyncWorker<ITargetingSource>(SyncVEFAbility, type, true);
             abilityAutoCastField = MP.RegisterSyncField(type, "autoCast");
             MpCompat.harmony.Patch(AccessTools.DeclaredMethod(type, "DoAction"),
                 prefix: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(PreAbilityDoAction)),
                 postfix: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(PostAbilityDoAction)));
-            MpCompat.harmony.Patch(AccessTools.DeclaredMethod(type, "DoTargeting"),
-                postfix: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(PostAbilityDoTargeting)));
 
             type = AccessTools.TypeByName("VFECore.CompShieldField");
             MpCompat.RegisterLambdaMethod(type, nameof(ThingComp.CompGetWornGizmosExtra), 0);
@@ -377,14 +375,6 @@ namespace Multiplayer.Compat
                 return;
 
             MP.WatchEnd();
-        }
-
-        private static void PostAbilityDoTargeting(ref int ___currentTargetingIndex, Def ___def)
-        {
-            // Normally the method would call CreateCastJob which would set it to -1,
-            // but since we sync that specific method we instead manually set it to -1
-            if (___currentTargetingIndex >= abilityDefTargetCountField(___def))
-                ___currentTargetingIndex = -1;
         }
 
         #endregion


### PR DESCRIPTION
Info on and reasoning about the patch:

- Instead of syncing `CreateCastJob`, we now sync `StartAbilityJob`
- `CreateCastJob` calls `StartAbilityJob`, but after all the calls to `AbilityExtension_AbilityMod.PreCast` - which could cancel the call
- The `PreCast` methods are passed `Action` which calls `StartAbilityJob`, so in case of confirmation dialog - it would end up calling it directly and end up not synced
- `CreateCastJob` does some cleanup (setting `currentTargetingIndex` to -1), so since we don't sync this method anymore we don't need a patch that does the cleanup

Info on testing:

- The changes were tested with Vanilla Psycasts Expanded (and submod) abilities, there seemed to be no issues (may need more testing, especially with other mods using the ability framework)
- The confirmation dialogs are used by Vanilla Psycasts Expanded - Hemosage (specifically Bloodstorm ability), possibly other mods/abilities