### PR TITLE
Another attempt at patching Performance Optimizer

### DIFF
--- a/Source/Mods/PerformanceOptimizer.cs
+++ b/Source/Mods/PerformanceOptimizer.cs
@@ -167,6 +167,9 @@ namespace Multiplayer.Compat
 
         private static IDictionary ReturnCorrectCache(IDictionary simulationCache)
         {
+            if (simulationCache == null)
+                return null;
+
             // If simulation, return normal cache
             if (!PatchingUtilities.ShouldCancel)
                 return simulationCache;
@@ -176,6 +179,7 @@ namespace Multiplayer.Compat
                 return interfaceCache;
 
             // This shouldn't ever run, but is here just in case something breaks.
+            Log.Warning($"Trying to get interface cache for dictionary of type: {simulationCache.GetType()}");
             interfaceCache = Activator.CreateInstance(simulationCache.GetType()) as IDictionary;
             SimulationToInterfaceCaches[simulationCache] = interfaceCache;
             return interfaceCache;

--- a/Source/Mods/PerformanceOptimizer.cs
+++ b/Source/Mods/PerformanceOptimizer.cs
@@ -1,4 +1,9 @@
-﻿using HarmonyLib;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
 using Multiplayer.API;
 using Verse;
 
@@ -10,8 +15,7 @@ namespace Multiplayer.Compat
     [MpCompatFor("Taranchuk.PerformanceOptimizer")]
     public class PerformanceOptimizer
     {
-        private static FastInvokeHandler refreshCache;
-        private static bool isAutoSaving = false;
+        #region Init
 
         public PerformanceOptimizer(ModContentPack mod)
         {
@@ -21,6 +25,7 @@ namespace Multiplayer.Compat
                 if (doTimeControlsHotkeys != null)
                     MpCompat.harmony.Patch(AccessTools.DeclaredMethod("PerformanceOptimizer.Optimization_DoPlaySettings_DoTimespeedControls:DoTimeControlsGUI"),
                         prefix: new HarmonyMethod(doTimeControlsHotkeys));
+                else Log.Error("Could not find TimeControlPatch:DoTimeControlsHotkeys, speed control hot keys won't work with disabled/hidden speed control UI.");
             }
 
             // Clear cache on join, etc.
@@ -30,7 +35,7 @@ namespace Multiplayer.Compat
                     prefix: new HarmonyMethod(typeof(PerformanceOptimizer), nameof(CancelIfAutosaving)));
                 refreshCache = MethodInvoker.GetHandler(resetDataMethod);
 
-                MpCompat.harmony.Patch(AccessTools.DeclaredMethod("Multiplayer.Client.MultiplayerSession:SaveGameToFile"),
+                MpCompat.harmony.Patch(AccessTools.DeclaredMethod("Multiplayer.Client.MultiplayerSession:SaveGameToFile_Overwrite"),
                     prefix: new HarmonyMethod(typeof(PerformanceOptimizer), nameof(PreSaveToFile)),
                     postfix: new HarmonyMethod(typeof(PerformanceOptimizer), nameof(PostSaveToFile)));
 
@@ -39,7 +44,79 @@ namespace Multiplayer.Compat
                 MpCompat.harmony.Patch(AccessTools.DeclaredMethod(typeof(GameComponentUtility), nameof(GameComponentUtility.FinalizeInit)),
                     postfix: new HarmonyMethod(typeof(PerformanceOptimizer), nameof(RefreshCachePrefix)));
             }
+
+            // Late patch, needs to run after Performance Optimizer init call.
+            // The usual LongEventHandler call won't work here.
+            {
+                MpCompat.harmony.Patch(
+                    AccessTools.DeclaredMethod("PerformanceOptimizer.PerformanceOptimizerSettings:Initialize"),
+                    postfix: new HarmonyMethod(typeof(PerformanceOptimizer), nameof(PostPerformanceOptimizerInitialize)));
+            }
         }
+
+        private static void PostPerformanceOptimizerInitialize()
+        {
+            // Separate caches from simulation and interface
+            // Those caches can be called from both interface and simulation code. This causes issues
+            // as the cache could end up getting recalculated from interface code and then accessed
+            // from simulation code, causing a desync. Our patches add another cache for all of them,
+            // and patches the methods so they access the proper cache based if it's simulation or interface.
+            // This ensures that those methods benefit from caching no matter the context, while also making
+            // sure that the game doesn't desync due to simulation relevant caches don't get modified from interface.
+            {
+                var transpiler = new HarmonyMethod(typeof(PerformanceOptimizer), nameof(SeparateCachesTranspiler));
+                var optimizationsList = AccessTools.DeclaredField("PerformanceOptimizer.PerformanceOptimizerSettings:throttles").GetValue(null) as IList;
+
+                if (optimizationsList != null)
+                {
+                    foreach (var optimization in optimizationsList)
+                    {
+                        var type = optimization.GetType();
+                        var (prefixName, postfixName) = type.Name switch
+                        {
+                            // Exceptions to default:
+                            // May seem pointless, but let's not risk issues
+                            "Optimization_InspectGizmoGrid_DrawInspectGizmoGridFor" => ("GetGizmosFast", null),
+                            // No postfix method
+                            "Optimization_Precept_RoleMulti_RecacheActivity" => ("Prefix", null),
+                            "Optimization_Precept_RoleSingle_RecacheActivity" => ("Prefix", null),
+                            "Optimization_Plant_TickLong" => ("Prefix", null),
+                            "Optimization_JobGiver_ConfigurableHostilityResponse" => ("Prefix", null),
+                            // Different name for prefix/postfix
+                            "Optimization_Building_Door_DoorRotationAt" => ("DoorRotationAtPrefix", "DoorRotationAtPostfix"),
+                            // Default methods to patch
+                            _ => ("Prefix", "Postfix")
+                        };
+
+                        if (prefixName != null)
+                        {
+                            var prefix = AccessTools.DeclaredMethod(type, prefixName);
+                            if (prefix != null)
+                                MpCompat.harmony.Patch(prefix, transpiler: transpiler);
+                            else
+                                Log.Error($"Type {type.FullName} is missing {prefixName} method, patching failed.");
+                        }
+
+                        if (postfixName != null)
+                        {
+                            var postfix = AccessTools.DeclaredMethod(type, postfixName);
+                            if (postfix != null)
+                                MpCompat.harmony.Patch(postfix, transpiler: transpiler);
+                            else
+                                Log.Error($"Type {type.FullName} is missing {postfixName} method, patching failed.");
+                        }
+                    }
+                }
+                else Log.Error("PerformanceOptimizer.PerformanceOptimizerSettings:throttles was null or empty, the patch was likely called too early.");
+            }
+        }
+
+        #endregion
+
+        #region Cache clearing patch
+
+        private static FastInvokeHandler refreshCache;
+        private static bool isAutoSaving = false;
 
         // While the game is saving, PerformanceOptimizer clears the cache.
         // However, in MP only the host is saving, but not the clients - we need to either clear for all, or for none.
@@ -49,9 +126,15 @@ namespace Multiplayer.Compat
             {
 #if DEBUG
                 if (Find.CurrentMap != null) 
-                    Log.Message($"{(isAutoSaving ? "Autosaving" : "Refreshing cache at")} at: {Find.TickManager?.TicksGame}");
+                    Log.Message($"{(isAutoSaving ? "Autosaving" : "Refreshing cache")} at: {Find.TickManager?.TicksGame}");
 #endif
-                return !isAutoSaving;
+                // Stop cache clearing when auto saving
+                if (isAutoSaving)
+                    return false;
+
+                // Clear our custom caches
+                ClearInterfaceCaches();
+                return true;
             }
 
 #if DEBUG
@@ -59,6 +142,8 @@ namespace Multiplayer.Compat
                 Log.Message($"Refreshing cache at: {Find.TickManager?.TicksGame}");
 #endif
             isAutoSaving = false;
+            // Clear our custom caches
+            ClearInterfaceCaches();
             return true;
         }
 
@@ -66,5 +151,64 @@ namespace Multiplayer.Compat
 
         private static void PreSaveToFile() => isAutoSaving = true;
         private static void PostSaveToFile() => isAutoSaving = false;
+
+        #endregion
+
+        #region Context-sensitive caches
+
+        private static readonly Dictionary<IDictionary, IDictionary> SimulationToInterfaceCaches = new();
+
+        // Should the cache clearing get postfixed to the Clear() method call of the class they inject into?
+        private static void ClearInterfaceCaches()
+        {
+            foreach (var cache in SimulationToInterfaceCaches.Values)
+                cache.Clear();
+        }
+
+        private static IDictionary ReturnCorrectCache(IDictionary simulationCache)
+        {
+            // If simulation, return normal cache
+            if (!PatchingUtilities.ShouldCancel)
+                return simulationCache;
+
+            // If interface, try to return the cache from our dictionary
+            if (SimulationToInterfaceCaches.TryGetValue(simulationCache, out var interfaceCache))
+                return interfaceCache;
+
+            // This shouldn't ever run, but is here just in case something breaks.
+            interfaceCache = Activator.CreateInstance(simulationCache.GetType()) as IDictionary;
+            SimulationToInterfaceCaches[simulationCache] = interfaceCache;
+            return interfaceCache;
+        }
+
+        private static IEnumerable<CodeInstruction> SeparateCachesTranspiler(IEnumerable<CodeInstruction> instr)
+        {
+            var replacementCall = AccessTools.DeclaredMethod(typeof(PerformanceOptimizer), nameof(ReturnCorrectCache));
+
+            foreach (var ci in instr)
+            {
+                yield return ci;
+
+                // Check for static is a bit pointless since the opcode is Ldsfld, but keeping it for safety anyway.
+                // Checking for the field name is a bit less unreliable in case mod changes, but so far all caches use the same name.
+                if (ci.opcode == OpCodes.Ldsfld && ci.operand is FieldInfo { IsStatic: true, Name: "cachedResults" } field)
+                {
+                    if (field.GetValue(null) is not IDictionary dict)
+                        continue;
+
+                    // Prepare the simulation-to-interface dictionary
+                    if (!SimulationToInterfaceCaches.ContainsKey(dict))
+                        SimulationToInterfaceCaches[dict] = Activator.CreateInstance(dict.GetType()) as IDictionary;
+
+                    // After the field with cache was accessed, call the method that'll replace it (if needed).
+                    yield return new CodeInstruction(OpCodes.Call, replacementCall);
+                }
+            }
+
+            // A lot of postfixes don't access the cache (they have the value out of cache passed as __state from prefix),
+            // so don't really bother logging if we haven't patched anything (unless debugging).
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
The patch was possibly thanks to Mutation Tracing tool released by Zetrith recently. Big thanks for the tool.

The patch should work, but I don't guarantee it 100%. It may turn out there's still something else that causes issues with Multiplayer that I could not find. But for now, let's hope for the best.

Changes/additions:
- The patch got split into regions
- Added a patch that makes the mod use separate cache for interface calls
- Added an error message time control hotkeys patch fails
- Fixed autosave patch by targeting the proper MP method (different name than earlier)