### PR TITLE
Compat for Dubs Central Heating and Dubs Bad Hygiene Lite

### DIFF
--- a/Source/Mods/BadHygiene.cs
+++ b/Source/Mods/BadHygiene.cs
@@ -4,10 +4,13 @@ using Verse;
 
 namespace Multiplayer.Compat
 {
-    /// <summary>Dubs Bad Hygiene by Dubwise</summary>
+    /// <summary>Dubs Bad Hygiene and Dubs Bad Hygiene Lite by Dubwise</summary>
     /// <see href="https://github.com/Dubwise56/Dubs-Bad-Hygiene"/>
+    /// <see href="https://github.com/Dubwise56/Dubs-Bad-Hygiene-Lite"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=836308268"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2570319432"/>
     [MpCompatFor("Dubwise.DubsBadHygiene")]
+    [MpCompatFor("Dubwise.DubsBadHygiene.Lite")]
     public class BadHygiene
     {
         private static AccessTools.FieldRef<Designator, ThingDef> removePlumbingRemovalModeField;

--- a/Source/Mods/DubsCentralHeating.cs
+++ b/Source/Mods/DubsCentralHeating.cs
@@ -1,0 +1,39 @@
+﻿using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Dubs Central Heating by Dubwise</summary>
+    /// <see href="https://github.com/Dubwise56/Dubs-Central-Heating"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2619214952"/>
+    [MpCompatFor("Dubwise.DubsCentralHeating")]
+    public class DubsCentralHeating
+    {
+        private static AccessTools.FieldRef<Designator, ThingDef> removePlumbingRemovalModeField;
+
+        public DubsCentralHeating(ModContentPack mod) => LongEventHandler.ExecuteWhenFinished(LatePatch);
+
+        private static void LatePatch()
+        {
+            // Designators
+            // Same patch as Bad Hygiene, different namespace.
+            var type = AccessTools.TypeByName("DubsCentralHeating.Designator_RemovePlumbing");
+            removePlumbingRemovalModeField = AccessTools.FieldRefAccess<ThingDef>(type, "RemovalMode");
+            MP.RegisterSyncWorker<Designator>(SyncRemovePlumbingDesignator, type, shouldConstruct: true);
+
+            // Patch all methods in the mod.
+            // It looks like it has all the required methods marked with SyncMethod attribute. It just never registers it.
+            // This is likely due to the mod source code being based on Bad Hygiene, just with unnecessary stuff stripped away.
+            MP.RegisterAll(type.Assembly);
+        }
+
+        private static void SyncRemovePlumbingDesignator(SyncWorker sync, ref Designator designator)
+        {
+            if (sync.isWriting)
+                sync.Write(removePlumbingRemovalModeField(designator));
+            else
+                removePlumbingRemovalModeField(designator) = sync.Read<ThingDef>();
+        }
+    }
+}


### PR DESCRIPTION
Bad Hygiene Lite uses the same assembly (although potentially a bit outdated?) as Bad Hygiene. It doesn't have everything that the non-lite version does, but the code is (basically) the same.

Central Heating assembly is a stripped-down version of Bad Hygiene assembly with the namespace being renamed as well. It still has all the `[SyncMethod]` attributes where those are needed, but it never call `MP.RegisterAll()` (as the class it was done it ended up being removed). Like Bad Hygiene, it also needs a sync worker for the deconstruct pipe designator.