### PR TITLE
Fix Performance Optimizer speed controls in SP

### DIFF
--- a/Source/Mods/PerformanceOptimizer.cs
+++ b/Source/Mods/PerformanceOptimizer.cs
@@ -23,8 +23,11 @@ namespace Multiplayer.Compat
             {
                 var doTimeControlsHotkeys = AccessTools.DeclaredMethod("Multiplayer.Client.AsyncTime.TimeControlPatch:DoTimeControlsHotkeys");
                 if (doTimeControlsHotkeys != null)
+                {
+                    doTimeControlsHotkeysMethod = MethodInvoker.GetHandler(doTimeControlsHotkeys);
                     MpCompat.harmony.Patch(AccessTools.DeclaredMethod("PerformanceOptimizer.Optimization_DoPlaySettings_DoTimespeedControls:DoTimeControlsGUI"),
-                        prefix: new HarmonyMethod(doTimeControlsHotkeys));
+                        prefix: new HarmonyMethod(typeof(PerformanceOptimizer), nameof(PreDoTimeControlsGUI)));
+                }
                 else Log.Error("Could not find TimeControlPatch:DoTimeControlsHotkeys, speed control hot keys won't work with disabled/hidden speed control UI.");
             }
 
@@ -211,6 +214,21 @@ namespace Multiplayer.Compat
 
             // A lot of postfixes don't access the cache (they have the value out of cache passed as __state from prefix),
             // so don't really bother logging if we haven't patched anything (unless debugging).
+        }
+
+        #endregion
+
+        #region Time controls
+
+        private static FastInvokeHandler doTimeControlsHotkeysMethod;
+
+        private static bool PreDoTimeControlsGUI()
+        {
+            if (!MP.IsInMultiplayer)
+                return true;
+
+            doTimeControlsHotkeysMethod(null);
+            return false;
         }
 
         #endregion


### PR DESCRIPTION
Fixes speed change using hotkeys if speed controls are hidden/disabled while playing in SP. The current patch unconditionally called the MP speed controls, despite not being in MP.

On top of that, this will prevent the mod time control hotkey method from running in MP, which was pointless as (in best case) it would almost immediately return or (in worst case scenario, if MP just handled time change) it would try running the time change code without a reason as it wouldn't be able to do anything anyway.