### PR TITLE
Attempt to fix #391

### DIFF
--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -1185,7 +1185,7 @@ namespace Multiplayer.Compat
         private static void PostIsConstruction(WorkGiver w, ref bool __result)
         {
             // If __result is true, the work type was construction, so MP allowed it.
-            if (__result || lastThing is not Thing thing || thing.def?.entityDefToBuild == null)
+            if (__result || lastThing is not Thing thing || thing.def?.entityDefToBuild?.modExtensions == null)
             {
                 lastThing = null;
                 return;
@@ -1194,17 +1194,19 @@ namespace Multiplayer.Compat
             // Look for the VFE def mod extension
             foreach (var extension in thing.def.entityDefToBuild.modExtensions)
             {
-                if (thingDefExtensionType.IsInstanceOfType(extension))
+                if (extension != null && thingDefExtensionType.IsInstanceOfType(extension))
                 {
                     // Get the construction skill requirement object
                     var constructionRequirement = thingDefExtensionConstructionSkillRequirementField(extension);
+                    if (constructionRequirement == null)
+                        break;
+
                     // Get the WorkTypeDef of the correct work requirement
                     var constructionWorkType = constructionSkillRequirementWorkTypeField(constructionRequirement);
                     // Set the result based on if the construction work type is the same as extension's work type.
                     __result = w.def.workType == constructionWorkType;
 
-                    lastThing = null;
-                    return;
+                    break;
                 }
             }
 


### PR DESCRIPTION
Couldn't test myself, as I could not reproduce the issue itself.

There's extra null check for:
- Def mod extensions list
- The currently checked def mod extension
- Construction requirement object (likely the culprit, but not 100% sure)

Things that aren't checked due to being guaranteed non-null at this point:
- WorkGiver, its def, and its work type (used by MP right before us, would cause NRE there)

Additional changes:
- The no returns in the loop itself, which got replaced by a break statement (the lastThing cleanup will happen outside of the loop)