### PR TITLE
Updated Vanilla Vehicles Expanded/added Tier 3 support

### DIFF
--- a/Source/Mods/VanillaVehiclesExpanded.cs
+++ b/Source/Mods/VanillaVehiclesExpanded.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using HarmonyLib;
+﻿using HarmonyLib;
 using Multiplayer.API;
 using Verse;
 
@@ -10,66 +9,33 @@ namespace Multiplayer.Compat
     [MpCompatFor("OskarPotocki.VanillaVehiclesExpanded")]
     public class VanillaVehiclesExpanded
     {
-        private static DesignationDef designationOpen;
-        private static DesignationDef designationClose;
-        private static AccessTools.FieldRef<object, Thing> innerClassParentField;
-
         public VanillaVehiclesExpanded(ModContentPack mod)
         {
-            LongEventHandler.ExecuteWhenFinished(LatePatch);
+            MpSyncWorkers.Requires<Designation>();
 
-            // Gizmos
-            {
-                var type = AccessTools.TypeByName("VanillaVehiclesExpanded.GarageDoor");
+            var type = AccessTools.TypeByName("VanillaVehiclesExpanded.GarageDoor");
 
-                // Open (0), close (2), and cancel (1, 3)
-                var methods = MpMethodUtil.GetLambda(type, "GetDoorGizmos", MethodType.Normal, null, 0, 1, 2, 3).ToList();
-                foreach (var method in methods)
-                {
-                    // Sync only with `<>4__this` field. `Designation` type doesn't have a sync worker, so we'll work around that.
-                    MP.RegisterSyncDelegate(type, method.DeclaringType.Name, method.Name, new[] { "<>4__this" });
-                }
+            // Open (0), close (2), and cancel (1, 3)
+            MpCompat.RegisterLambdaDelegate(type, "GetDoorGizmos", 0, 1, 2, 3);
 
-                innerClassParentField = AccessTools.FieldRefAccess<Thing>(methods[0].DeclaringType, "<>4__this");
-                // A workaround for the lack of sync worker for `Designation`. Add a prefix that will set up the fields as needed.
-                MpCompat.harmony.Patch(methods[1], prefix: new HarmonyMethod(typeof(VanillaVehiclesExpanded), nameof(PreCancelOpen)));
-                MpCompat.harmony.Patch(methods[3], prefix: new HarmonyMethod(typeof(VanillaVehiclesExpanded), nameof(PreCancelClose)));
+            // Open/close gizmo from GarageAutoDoor
+            MP.RegisterSyncMethod(type, "StartOpening");
+            MP.RegisterSyncMethod(type, "StartClosing");
 
-                // Open/close gizmo from GarageAutoDoor
-                MP.RegisterSyncMethod(type, "StartOpening");
-                MP.RegisterSyncMethod(type, "StartClosing");
-            }
-        }
+            // Toggle fridge on/off
+            type = AccessTools.TypeByName("VanillaVehiclesExpanded.CompRefrigerator");
+            MpCompat.RegisterLambdaMethod(type, nameof(ThingComp.CompGetGizmosExtra), 1);
 
-        private static void LatePatch()
-        {
-            designationOpen = DefDatabase<DesignationDef>.GetNamed("VVE_Open");
-            designationClose = DefDatabase<DesignationDef>.GetNamed("VVE_Close");
-        }
+            // Reloadable verb
+            type = AccessTools.TypeByName("VanillaVehiclesExpanded.CompReloadableWithVerbs");
+            MP.RegisterSyncMethod(type, "TryReload");
+            // (Dev) reload to full
+            MpCompat.RegisterLambdaMethod(type, nameof(ThingComp.CompGetGizmosExtra), 0).SetDebugOnly();
 
-        private static bool PreCancelOpen(object __instance, ref Designation ___openDesignation)
-        {
-            if (MP.IsInMultiplayer)
-                return GetTargetDesignation(__instance, ref ___openDesignation, designationOpen);
-            return true;
-        }
-
-        private static bool PreCancelClose(object __instance, ref Designation ___closeDesignation)
-        {
-            if (MP.IsInMultiplayer)
-                return GetTargetDesignation(__instance, ref ___closeDesignation, designationClose);
-            return true;
-        }
-
-        private static bool GetTargetDesignation(object instance, ref Designation fieldRef, DesignationDef targetDesignation)
-        {
-            if (targetDesignation == null)
-                return false;
-
-            var building = innerClassParentField(instance);
-            fieldRef = building.Map.designationManager.DesignationOn(building, targetDesignation);
-
-            return true;
+            // Restore wreck
+            type = AccessTools.TypeByName("VanillaVehiclesExpanded.CompVehicleWreck");
+            // Restore (0)/cancel (1)
+            MpCompat.RegisterLambdaDelegate(type, nameof(ThingComp.CompGetGizmosExtra), 0, 1);
         }
     }
 }

--- a/Source/MpSyncWorkers.cs
+++ b/Source/MpSyncWorkers.cs
@@ -92,9 +92,9 @@ namespace Multiplayer.Compat
                     var def = sync.Read<DesignationDef>();
 
                     if (target.HasThing)
-                        manager.DesignationOn(target.Thing, def);
+                        designation = manager.DesignationOn(target.Thing, def);
                     else
-                        manager.DesignationAt(target.Cell, def);
+                        designation = manager.DesignationAt(target.Cell, def);
                 }
             }
         }


### PR DESCRIPTION
Anything from VVE Tier 3 that needed patching was included in the original vehicle mod (despite it not using it), so it acts as a framework. No need for separate patch for Tier 3 assembly, as it barely does anything (and nothing that needs patching).

Added temporary sync workers for Designation and DesignationManager, simplifying existing patch and one of the new ones.

Currently, one of the vehicles (Bunsen) causes desyncs when using its turrets. Currently investigating it, but seems like it _may_ be an issue with Vanilla Expanded Framework. Not 100% sure yet.