### PR TITLE
Update mods to use API version 0.5

### DIFF
--- a/Source/Mods/AllowTool.cs
+++ b/Source/Mods/AllowTool.cs
@@ -143,9 +143,6 @@ namespace Multiplayer.Compat
 
             // Recache haul urgently deterministically (currently uses Time.unscaledTime)
             {
-                // Used by DeterministicallyHandleReCaching
-                PatchingUtilities.InitCancelInInterface();
-
                 var type = AccessTools.TypeByName("AllowTool.HaulUrgentlyCacheHandler");
                 MpCompat.harmony.Patch(AccessTools.Method(type, "RecacheIfNeeded"),
                     prefix: new HarmonyMethod(typeof(AllowTool), nameof(DeterministicallyHandleReCaching)));
@@ -306,7 +303,7 @@ namespace Multiplayer.Compat
             if (!MP.IsInMultiplayer)
                 return true;
             // Can be called from MonoBehaviour.FixedUpdate and operates on a single map only, cancel in such cases
-            if (PatchingUtilities.ShouldCancel)
+            if (MP.InInterface)
                 return false;
 
             currentTime = Find.TickManager.TicksGame;

--- a/Source/Mods/MoreFactionInteraction.cs
+++ b/Source/Mods/MoreFactionInteraction.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using HarmonyLib;
 using Multiplayer.API;
 using Verse;
@@ -14,16 +13,11 @@ namespace Multiplayer.Compat
     {
         public MoreFactionInteraction(ModContentPack mod)
         {
-            Type type = AccessTools.TypeByName("Multiplayer.Client.Patches.CloseDialogsForExpiredLetters");
-            // We should probably add this to the API the next time we update it
-            // TODO: Expose in API
-            var registerAction = AccessTools.Method(type, "RegisterDefaultLetterChoice");
-
-            type = AccessTools.TypeByName("MoreFactionInteraction.ChoiceLetter_ReverseTradeRequest");
+            var type = AccessTools.TypeByName("MoreFactionInteraction.ChoiceLetter_ReverseTradeRequest");
             var methods = MpMethodUtil.GetLambda(type, "Choices", MethodType.Getter, null, 0, 3).ToArray();
             MP.RegisterSyncDelegate(type, methods[0].DeclaringType.Name, methods[0].Name);
             MP.RegisterSyncMethod(methods[1]);
-            registerAction.Invoke(null, new object[] {methods[1], type});
+            MP.RegisterDefaultLetterChoice(methods[1], type);
 
             var typeNames = new[]
             {
@@ -38,7 +32,7 @@ namespace Multiplayer.Compat
                 methods = MpMethodUtil.GetLambda(type, "Choices", MethodType.Getter, null, 0, 1).ToArray();
                 MP.RegisterSyncMethod(methods[0]);
                 MP.RegisterSyncMethod(methods[1]);
-                registerAction.Invoke(null, new object[] {methods[1], type});
+                MP.RegisterDefaultLetterChoice(methods[1], type);
             }
 
             typeNames = new[]

--- a/Source/Mods/PerformanceOptimizer.cs
+++ b/Source/Mods/PerformanceOptimizer.cs
@@ -174,7 +174,7 @@ namespace Multiplayer.Compat
                 return null;
 
             // If simulation, return normal cache
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return simulationCache;
 
             // If interface, try to return the cache from our dictionary

--- a/Source/Mods/ResearchPowl.cs
+++ b/Source/Mods/ResearchPowl.cs
@@ -95,7 +95,7 @@ namespace Multiplayer.Compat
         private static bool PreSanityCheck(WorldComponent __instance, IList ____queue)
         {
             // Let it run normally in SP or in synced commands (or other contexts not needing syncing)
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             foreach (var node in ____queue)

--- a/Source/Mods/RimsentialSpaceports.cs
+++ b/Source/Mods/RimsentialSpaceports.cs
@@ -33,16 +33,12 @@ namespace Multiplayer.Compat
 
             // Choice letters
             {
-                var type = AccessTools.TypeByName("Multiplayer.Client.Patches.CloseDialogsForExpiredLetters");
-                // We should probably add this to the API the next time we update it
-                var registerAction = AccessTools.DeclaredMethod(type, "RegisterDefaultLetterChoice");
-
-                type = AccessTools.TypeByName("Spaceports.Letters.PrisonerTransferLetter");
+                var type = AccessTools.TypeByName("Spaceports.Letters.PrisonerTransferLetter");
                 var methods = MpMethodUtil.GetLambda(type, "Choices", MethodType.Getter, null, 0, 1, 2).ToArray();
                 MP.RegisterSyncMethod(methods[0]);
                 MP.RegisterSyncMethod(methods[1]);
                 MP.RegisterSyncMethod(methods[2]);
-                registerAction.Invoke(null, new object[] { methods[2], type });
+                MP.RegisterDefaultLetterChoice(methods[2], type);
 
                 var typeNames = new[]
                 {
@@ -58,7 +54,7 @@ namespace Multiplayer.Compat
                     methods = MpMethodUtil.GetLambda(type, "Choices", MethodType.Getter, null, 0, 1).ToArray();
                     MP.RegisterSyncMethod(methods[0]);
                     MP.RegisterSyncMethod(methods[1]);
-                    registerAction.Invoke(null, new object[] { methods[1], type });
+                    MP.RegisterDefaultLetterChoice(methods[1], type);
                 }
             }
         }

--- a/Source/Mods/RunandGun.cs
+++ b/Source/Mods/RunandGun.cs
@@ -15,7 +15,7 @@ namespace Multiplayer.Compat
         {
             Type type = AccessTools.TypeByName("RunAndGun.Harmony.Pawn_DraftController_GetGizmos_Patch");
 
-            MP.RegisterSyncDelegate(type, "<>c__DisplayClass0_0", "<Postfix>b__1");
+            MP.RegisterSyncDelegateLambda(type, "Postfix", 1);
 
             PatchingUtilities.PatchSystemRand("RunAndGun.Harmony.MentalStateHandler_TryStartMentalState:shouldRunAndGun", false);
         }

--- a/Source/Mods/SRTSExpanded.cs
+++ b/Source/Mods/SRTSExpanded.cs
@@ -56,7 +56,6 @@ namespace Multiplayer.Compat
             var tryLaunch = AccessTools.Method(type, "TryLaunch");
             tryLaunchMethod = MethodInvoker.GetHandler(tryLaunch);
 
-            PatchingUtilities.InitCancelInInterface();
             MpCompat.harmony.Patch(tryLaunch, prefix: new HarmonyMethod(typeof(SRTSExpanded), nameof(PreTryLaunch)));
             MP.RegisterSyncMethod(typeof(SRTSExpanded), nameof(SyncedLaunch)).ExposeParameter(2);
 
@@ -83,7 +82,7 @@ namespace Multiplayer.Compat
         private static bool PreTryLaunch(ThingComp __instance, int destinationTile, TransportPodsArrivalAction arrivalAction, Caravan cafr = null)
         {
             // Let the method run only if it's synced call
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             var caravanFieldValue = caravanField(__instance);
@@ -142,7 +141,7 @@ namespace Multiplayer.Compat
         private static bool PreAddPawns(ThingComp __instance, List<Pawn> ___tmpAllowedPawns)
         {
             // Let the method run only if it's synced call
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             SyncedAddPawns(__instance, ___tmpAllowedPawns);

--- a/Source/Mods/SimpleSidearms.cs
+++ b/Source/Mods/SimpleSidearms.cs
@@ -123,7 +123,7 @@ namespace Multiplayer.Compat
         [MpCompatPrefix("PeteTimesSix.SimpleSidearms.Utilities.GettersFilters", "findBestRangedWeapon", 8)]
         private static bool PrePrimaryVerbMethodCall(ThingWithComps __0, ref bool __result)
         {
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             var comp = __0.GetComp<CompEquippable>();

--- a/Source/Mods/VanillaAnimalsEndangered.cs
+++ b/Source/Mods/VanillaAnimalsEndangered.cs
@@ -14,7 +14,7 @@ namespace Multiplayer.Compat
         {
             var type = AccessTools.TypeByName("VanillaAnimalsExpandedEndangered.Pawn_GetGizmos_Patch");
 
-            MP.RegisterSyncDelegate(type, "<>c__DisplayClass3_0", "<Postfix>b__1");
+            MP.RegisterSyncDelegateLambda(type, "Postfix", 1);
         }
     }
 }

--- a/Source/Mods/VanillaFactionsPirates.cs
+++ b/Source/Mods/VanillaFactionsPirates.cs
@@ -50,7 +50,6 @@ namespace Multiplayer.Compat
                 // The code using the ability returns true, and we need to make sure it happens because
                 // as far as I understand, sync method on non-void methods returns default value (which
                 // would be false for bool)
-                PatchingUtilities.InitCancelInInterface();
                 MP.RegisterSyncMethod(typeof(VanillaFactionsPirates), nameof(SyncedShieldDetonation));
                 MpCompat.harmony.Patch(AccessTools.Method("VFEPirates.Verb_ShieldDetonation:TryCastShot"),
                     prefix: new HarmonyMethod(typeof(VanillaFactionsPirates), nameof(PreShieldDetonation)));
@@ -246,7 +245,7 @@ namespace Multiplayer.Compat
 
         private static bool PreShieldDetonation(Verb __instance, ref bool __result)
         {
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             // We need to sync as ThingComp, as MP only supports 2 comps - CompEquippable and CompReloadable

--- a/Source/Mods/VanillaHairExpanded.cs
+++ b/Source/Mods/VanillaHairExpanded.cs
@@ -50,7 +50,6 @@ namespace Multiplayer.Compat
             beardDefField = AccessTools.Field(type, "beardDef");
             hairColourField = AccessTools.Field(type, "hairColour");
 
-            PatchingUtilities.InitCancelInInterface();
             MpCompat.harmony.Patch(AccessTools.Method(typeof(WindowStack), nameof(WindowStack.TryRemove), new[] { typeof(Window), typeof(bool) }),
                 prefix: new HarmonyMethod(typeof(VanillaHairExpanded), nameof(PreTryRemoveWindow)));
 
@@ -77,7 +76,7 @@ namespace Multiplayer.Compat
         private static bool PreTryRemoveWindow(Window window)
         {
             // Let the method run only if it's synced call
-            if (!PatchingUtilities.ShouldCancel || window.GetType() != changeHairstyleDialogType)
+            if (!MP.InInterface || window.GetType() != changeHairstyleDialogType)
                 return true;
 
             SyncedTryRemoveWindow();

--- a/Source/Mods/VanillaPlantsAutoPlowPatch.cs
+++ b/Source/Mods/VanillaPlantsAutoPlowPatch.cs
@@ -10,6 +10,6 @@ namespace Multiplayer.Compat
     class VanillaPlantsAutoPlowPatch
     {
         public VanillaPlantsAutoPlowPatch(ModContentPack mod)
-            => MP.RegisterSyncDelegate(AccessTools.TypeByName("VPEAutoPlow.Patch_Zone_Growing_GetGizmos"), "<>c__DisplayClass0_0", "<Add_AllowAutoPlow_Gizmo>b__1");
+            => MP.RegisterSyncDelegateLambda(AccessTools.TypeByName("VPEAutoPlow.Patch_Zone_Growing_GetGizmos"), "Add_AllowAutoPlow_Gizmo", 1);
     }
 }

--- a/Source/Mods/VanillaRacesAndroid.cs
+++ b/Source/Mods/VanillaRacesAndroid.cs
@@ -222,10 +222,7 @@ namespace Multiplayer.Compat
                 // https://github.com/rwmt/Multiplayer/blob/c7a673a63178257fbcbbe4812b0d48f0e8df2593/Source/Client/Syncing/Game/SyncDelegates.cs#L277-L279
                 // https://github.com/rwmt/Multiplayer/blob/c7a673a63178257fbcbbe4812b0d48f0e8df2593/Source/Client/Syncing/Game/SyncDelegates.cs#L331-L356
 
-                var type = AccessTools.TypeByName("Multiplayer.Client.Patches.CloseDialogsForExpiredLetters");
-                var registerAction = AccessTools.DeclaredMethod(type, "RegisterDefaultLetterChoice");
-
-                type = AccessTools.TypeByName("VREAndroids.ChoiceLetter_AndroidAwakened");
+                var type = AccessTools.TypeByName("VREAndroids.ChoiceLetter_AndroidAwakened");
 
                 var method = AccessTools.DeclaredMethod(type, "MakeChoices");
                 MP.RegisterSyncMethod(method).ExposeParameter(1);
@@ -243,13 +240,7 @@ namespace Multiplayer.Compat
                 passionChoicesField = AccessTools.FieldRefAccess<List<SkillDef>>(type, "passionChoices");
                 traitChoicesField = AccessTools.FieldRefAccess<List<Trait>>(type, "traitChoices");
 
-                registerAction.Invoke(
-                    null,
-                    new object[]
-                    {
-                        AccessTools.DeclaredMethod(typeof(VanillaRacesAndroid), nameof(DefaultDialogSelection)),
-                        type
-                    });
+                MP.RegisterDefaultLetterChoice(AccessTools.DeclaredMethod(typeof(VanillaRacesAndroid), nameof(DefaultDialogSelection)), type);
 
                 type = AccessTools.TypeByName("VREAndroids.Dialog_AndroidAwakenedChoices");
                 MpCompat.harmony.Patch(AccessTools.DeclaredMethod(type, nameof(Window.DoWindowContents)),

--- a/Source_Referenced/CashRegister.cs
+++ b/Source_Referenced/CashRegister.cs
@@ -33,7 +33,6 @@ namespace Multiplayer.Compat
 
                 MP.RegisterSyncWorker<Shift>(SyncShift);
 
-                PatchingUtilities.InitCancelInInterface();
                 MpCompat.harmony.Patch(AccessTools.DeclaredMethod(typeof(CompAssignableToPawn), nameof(CompAssignableToPawn.TryAssignPawn)),
                     prefix: new HarmonyMethod(typeof(CashRegister), nameof(PreTryAssignPawn)));
                 MpCompat.harmony.Patch(AccessTools.DeclaredMethod(typeof(CompAssignableToPawn), nameof(CompAssignableToPawn.TryUnassignPawn)),
@@ -195,7 +194,7 @@ namespace Multiplayer.Compat
         private static bool PreTryAssignPawn(CompAssignableToPawn __instance, Pawn pawn)
         {
             // Only catch the comp from CashRegister mod
-            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel || __instance is not CompAssignableToPawn_Shifts shift)
+            if (!MP.IsInMultiplayer || !MP.InInterface || __instance is not CompAssignableToPawn_Shifts shift)
                 return true;
 
             SyncedTryAssignPawnShifts(shift, pawn, GetRegisterShiftToIndex(shift));
@@ -207,7 +206,7 @@ namespace Multiplayer.Compat
         private static bool PreTryUnassignPawn(CompAssignableToPawn __instance, Pawn pawn)
         {
             // Only catch the comp from CashRegister mod
-            if (!MP.IsInMultiplayer || !PatchingUtilities.ShouldCancel || __instance is not CompAssignableToPawn_Shifts shift)
+            if (!MP.IsInMultiplayer || !MP.InInterface || __instance is not CompAssignableToPawn_Shifts shift)
                 return true;
 
             SyncedTryUnassignPawnShifts(shift, pawn, GetRegisterShiftToIndex(shift));

--- a/Source_Referenced/VehicleFramework.cs
+++ b/Source_Referenced/VehicleFramework.cs
@@ -69,7 +69,6 @@ namespace Multiplayer.Compat
 
             // Should be initialized by PatchCancelInInterface calls later on,
             // so this exists here as an extra safety in case those ever get removed later on.
-            PatchingUtilities.InitCancelInInterface();
             MpCompatPatchLoader.LoadPatch<VehicleFramework>();
 
             #endregion
@@ -916,7 +915,7 @@ namespace Multiplayer.Compat
         // the current mouse position, which we don't want and it's a feature we've disabled in MP.
         // There's however only 1 situation that it's not the case, this will handle it.
         // The situation is pressing the gizmo's cancel button to stop targetting att all.
-        private static bool CancelTurretSetTargetSync() => shouldSyncInInterface || !PatchingUtilities.ShouldCancel;
+        private static bool CancelTurretSetTargetSync() => shouldSyncInInterface || !MP.InInterface;
 
         private static void SyncSetTarget(VehicleTurret turret, LocalTargetInfo target)
         {
@@ -1658,7 +1657,7 @@ namespace Multiplayer.Compat
 
         private static bool PreNotifyChoseRoute(Dialog_FormVehicleCaravan __instance, int destinationTile)
         {
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             MP.GetLocalSessionManager(__instance.map).GetFirstOfType<FormVehicleCaravanSession>()?.ChooseRoute(destinationTile);
@@ -1667,7 +1666,7 @@ namespace Multiplayer.Compat
 
         private static bool PreTryReformCaravan(Dialog_FormVehicleCaravan __instance)
         {
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             MP.GetLocalSessionManager(__instance.map).GetFirstOfType<FormVehicleCaravanSession>()?.TryReformCaravan();
@@ -1676,7 +1675,7 @@ namespace Multiplayer.Compat
 
         private static bool PreTryFormAndSendCaravan(Dialog_FormVehicleCaravan __instance)
         {
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             MP.GetLocalSessionManager(__instance.map).GetFirstOfType<FormVehicleCaravanSession>()?.TryFormAndSendCaravan();
@@ -1685,7 +1684,7 @@ namespace Multiplayer.Compat
 
         private static bool PreDebugTryFormCaravanInstantly(Dialog_FormVehicleCaravan __instance)
         {
-            if (!PatchingUtilities.ShouldCancel)
+            if (!MP.InInterface)
                 return true;
 
             MP.GetLocalSessionManager(__instance.map).GetFirstOfType<FormVehicleCaravanSession>()?.DebugTryFormCaravanInstantly();
@@ -2494,7 +2493,7 @@ namespace Multiplayer.Compat
         [MpCompatPrefix(typeof(VehicleTurret), nameof(VehicleTurret.TurretRotation), methodType: MethodType.Getter)]
         private static void PreTurretRotation(VehicleTurret __instance, float ___rotation, ref float? __state)
         {
-            if (PatchingUtilities.ShouldCancel)
+            if (MP.InInterface)
                 __state = ___rotation;
         }
 
@@ -2511,7 +2510,7 @@ namespace Multiplayer.Compat
             // A couple of places during ticking check the current turret from the targeter. This will cause
             // issues due to conditional statements based on `TurretTargeter.Turret != this`, etc. so just
             // prevent the mod from returning the actual turret in interface (return default value/null).
-            return PatchingUtilities.ShouldCancel; // The inverse of what PatchingUtilities.PatchCancelInInterface does
+            return MP.InInterface; // The inverse of what PatchingUtilities.PatchCancelInInterface does
         }
 
         #endregion


### PR DESCRIPTION
Changes:

- `PatchingUtilities.InitCancelInInterface()` completely removed
- `PatchingUtilities.ShouldCancel` removed, calls to it replaced with `MP.InInterface`
- Use `MP.RegisterDefaultLetterChoice` instead of accessing MP types/methods directly
- `MP.RegisterSyncDelegate` using compiler-generated names replaced with `MP.RegisterSyncDelegateLambda`
- Vanilla Expanded Framework DoorTeleporter uses `TransformField` and `MP.TryGetThingById` instead of operating on compiler-generated classes/methods directly
- Vanilla Factions Expanded - Empire uses `TransformField` and `MP.CanUseDevMode`, removed the temporary patch

The one major thing that this doesn't cover is the usage of sessions as a replacement for pause locks.