### PR TITLE
Fix #398

### DIFF
--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -184,7 +184,7 @@ namespace Multiplayer.Compat
             MpCompat.RegisterLambdaDelegate(
                 "VFECore.SocialCardUtility_DrawPregnancyApproach_Patch", 
                 "AddPregnancyApproachOptions",
-                0, 1); // Disable extra approaches (0), set extra approach (1)
+                0, 2); // Disable extra approaches (0), set extra approach (2)
         }
 
         private static void PatchExpandableProjectile()


### PR DESCRIPTION
Quick look at decompiler revealed that another lambda delegate was added to the method (used for `list.Any()` predicate), which took the ordinal of the method we were syncing and basically moved it by 1.

Haven't really tested it, but the change is so tiny it should just work fine.