### PR TITLE
Update release_bundler.sh to include 'Languages' dir

### DIFF
--- a/release_bundler.sh
+++ b/release_bundler.sh
@@ -11,7 +11,7 @@ cd ..
 rm -rf Multiplayer-Compatibility/
 mkdir -p Multiplayer-Compatibility
 
-cp -r About Assemblies Referenced Multiplayer-Compatibility
+cp -r About Assemblies Referenced Languages Multiplayer-Compatibility
 
 # Zip for Github releases
 rm -f Multiplayer-Compatibility.zip


### PR DESCRIPTION
We'll need to include language data going forward due to most (if not all) compats using sessions needing them. Currently this only includes Vehicle Framework, but the list will grow in the future.