### PR TITLE
Fix null Designation sync worker

### DIFF
--- a/Source/MpSyncWorkers.cs
+++ b/Source/MpSyncWorkers.cs
@@ -74,20 +74,21 @@ namespace Multiplayer.Compat
         {
             if (sync.isWriting)
             {
-                sync.Write(designation?.designationManager);
+                var canSync = designation?.designationManager != null;
+                sync.Write(canSync);
 
-                if (designation != null)
+                if (canSync)
                 {
+                    sync.Write(designation.designationManager);
                     sync.Write(designation.target);
                     sync.Write(designation.def);
                 }
             }
             else
             {
-                var manager = sync.Read<DesignationManager>();
-
-                if (manager != null)
+                if (sync.Read<bool>())
                 {
+                    var manager = sync.Read<DesignationManager>();
                     var target = sync.Read<LocalTargetInfo>();
                     var def = sync.Read<DesignationDef>();
 
@@ -102,9 +103,9 @@ namespace Multiplayer.Compat
         private static void SyncDesignationManager(SyncWorker sync, ref DesignationManager manager)
         {
             if (sync.isWriting)
-                sync.Write(manager?.map);
+                sync.Write(manager.map);
             else
-                manager = sync.Read<Map>()?.designationManager;
+                manager = sync.Read<Map>().designationManager;
         }
 
         private static bool HasSyncWorker(Type type)


### PR DESCRIPTION
The issue is caused due to how MP syncs maps. Basically what happened was DesignationManager writing a null map, and reading a non-null one - which caused Designation sync worker to assume it's supposed to receive non-null value. Basically:

```csharp
if (sync.IsWriting)
{
    Map map = null;
    // Write null map
    sync.Write(map);
    Log.Error($"{map == null}"); // true
}
else
{
    var map = sync.Read<Map>();
    // Read a map which is not null
    Log.Error($"{map == null}"); // false
}
```

This happens due to MP syncing map by using `data.MpContext().map = map`, so if another sync worker delegate sets the value - the null map we've tried to sync is now non-null:
https://github.com/rwmt/Multiplayer/blob/7429f3a8870a8696e5829de31a831c8d0f16ce4b/Source/Client/Syncing/Dict/SyncDictRimWorld.cs#L800-L803

The changes applied here to fix the issue:
- DesignationManager always assumes it's syncing a non-null value (same as AreaManager and few other MP sync workers)
- Designation before syncing rest of the data first writes a bool which determines if the value is null or not (since writing a null DesignationManager would result in a non-null value)