### PR TITLE
A few extra determinism patches for Vehicle Framework

### DIFF
--- a/Source_Referenced/VehicleFramework.cs
+++ b/Source_Referenced/VehicleFramework.cs
@@ -2513,6 +2513,38 @@ namespace Multiplayer.Compat
             return !MP.IsInMultiplayer || MP.InInterface; // The inverse of what PatchingUtilities.PatchCancelInInterface does
         }
 
+        [MpCompatPrefix(typeof(VehicleTweener), nameof(VehicleTweener.TweenedPos), methodType: MethodType.Getter)]
+        private static bool PreTweenedPosGetter(VehicleTweener __instance, ref Vector3 __result)
+        {
+            // Out of MP or in interface, return the tweened pos
+            if (!MP.IsInMultiplayer || MP.InInterface)
+                return true;
+
+            // Give the root position during ticking, same as MP does with pawns.
+            __result = __instance.TweenedPosRoot();
+            return false;
+        }
+
+        [MpCompatPrefix(typeof(VehiclePawn), nameof(VehiclePawn.DrawAt),
+            new[] { typeof(Vector3), typeof(bool) })]
+        [MpCompatPrefix(typeof(VehiclePawn), nameof(VehiclePawn.DrawAt),
+            new[] { typeof(Vector3), typeof(Rot8), typeof(float), typeof(bool), typeof(bool) })]
+        private static void PreRenderPawnInternal(VehiclePawn __instance, ref (Rot4 rotation, float angle)? __state)
+        {
+            if (MP.InInterface)
+                __state = (__instance.Rotation, __instance.angle);
+        }
+
+        [MpCompatFinalizer(typeof(VehiclePawn), nameof(VehiclePawn.DrawAt),
+            new[] { typeof(Vector3), typeof(bool) })]
+        [MpCompatFinalizer(typeof(VehiclePawn), nameof(VehiclePawn.DrawAt),
+            new[] { typeof(Vector3), typeof(Rot8), typeof(float), typeof(bool), typeof(bool) })]
+        private static void PostRenderPawnInternal(VehiclePawn __instance, ref (Rot4 rotation, float angle)? __state)
+        {
+            if (__state is {} state)
+                (__instance.Rotation, __instance.angle) = (state.rotation, state.angle);
+        }
+
         #endregion
 
         #region Route Planner


### PR DESCRIPTION
First one is for vehicle tweener - it's the same patch that MP applies to normal pawns, where during ticking it'll return the `TweenedPosRoot` instead of the actual tweened position. This will cause some minor graphical issues where projectiles will spawn outside of the vehicle turret, but will prevent situations where the projectile was spawned at a different position for each player.

The second one is changing the vehicle's rotation (Rot4) and angle (float) - both used to calculate vehicle's true rotation (Rot8). The change here is to not allow those 2 values to be modified while drawing (changes kept temporarily for drawing proper position, but then discarded).