### PR TITLE
Fix Vehicle Framework multi pawn enter vehicle float menu

### DIFF
--- a/Source_Referenced/VehicleFramework.cs
+++ b/Source_Referenced/VehicleFramework.cs
@@ -222,7 +222,7 @@ namespace Multiplayer.Compat
             {
                 // Enter vehicle. Can't sync through TryTakeOrderedJob, as the method does a bit more stuff.
                 MpCompat.RegisterLambdaDelegate(typeof(VehiclePawn), nameof(VehiclePawn.GetFloatMenuOptions), 0);
-                MpCompat.RegisterLambdaDelegate(typeof(VehiclePawn), nameof(VehiclePawn.MultiplePawnFloatMenuOptions), 0);
+                MpCompat.RegisterLambdaDelegate(typeof(VehiclePawn), nameof(VehiclePawn.MultiplePawnFloatMenuOptions), 1);
             }
 
             #endregion


### PR DESCRIPTION
Seems it broke due to there being a new delegate (used to check if ideology forbids vehicle usage), which was now synced instead.