### PR TITLE
Fix MVCF verb manager ticking with async time

### DIFF
--- a/Source/PatchingUtilities.cs
+++ b/Source/PatchingUtilities.cs
@@ -693,5 +693,42 @@ namespace Multiplayer.Compat
         }
 
         #endregion
+
+        #region Async Time
+
+        private static bool isAsyncTimeSetup = false;
+        private static bool isAsyncTimeSuccessful = false;
+        private static AccessTools.FieldRef<object> multiplayerGameField;
+        private static AccessTools.FieldRef<object, object> gameGameCompField;
+        private static AccessTools.FieldRef<object, bool> gameCompAsyncTimeField;
+
+        public static bool IsAsyncTime
+            => isAsyncTimeSuccessful &&
+               gameCompAsyncTimeField(gameGameCompField(multiplayerGameField()));
+
+        public static void SetupAsyncTime()
+        {
+            if (isAsyncTimeSetup)
+                return;
+            isAsyncTimeSetup = true;
+
+            try
+            {
+                multiplayerGameField = AccessTools.StaticFieldRefAccess<object>(
+                    AccessTools.DeclaredField("Multiplayer.Client.Multiplayer:game"));
+                gameGameCompField = AccessTools.FieldRefAccess<object>(
+                    "Multiplayer.Client.MultiplayerGame:gameComp");
+                gameCompAsyncTimeField = AccessTools.FieldRefAccess<bool>(
+                    "Multiplayer.Client.Comp.MultiplayerGameComp:asyncTime");
+
+                isAsyncTimeSuccessful = true;
+            }
+            catch (Exception e)
+            {
+                Log.Error($"Encountered an exception while settings up async time:\n{e}");
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Should fix the issue with mini-turret packs (and similar apparel) shooting on maps that are paused, along with a couple of other issues.

The issue happened due to the verb managers ticking inside of world component. The change here was to:
- In existing WorldComp ticking, only tick verb managers that have no pawn or a pawn with no map
- Added map ticking where the comp's pawn map is checked and and ticked if the map was ticked
- However, this is inactive if async time is off and the mod should tick as it normally would in such cases

Also includes some minor changes, like removing the unused field and slight renames for consistency.