### PR TITLE
Updated Biomes! Core compat

### DIFF
--- a/Source/DebugActions.cs
+++ b/Source/DebugActions.cs
@@ -68,6 +68,12 @@ namespace Multiplayer.Compat
             AccessTools.DeclaredMethod("HugsLib.ModBase:Update"),
             AccessTools.DeclaredMethod("HugsLib.ModBase:FixedUpdate"),
             AccessTools.DeclaredMethod("HugsLib.ModBase:OnGUI"),
+            AccessTools.DeclaredMethod("BiomesCore.TerrainInstance:Update"),
+            AccessTools.DeclaredMethod("BiomesCore.TerrainComp:CompUpdate"),
+            AccessTools.DeclaredMethod("BiomesCore.DefExtensionActive:DoWork", new [] { AccessTools.TypeByName("Verse.TerrainDef") }),
+            AccessTools.DeclaredMethod("VFECore.TerrainInstance:Update"),
+            AccessTools.DeclaredMethod("VFECore.TerrainComp:CompUpdate"),
+            AccessTools.DeclaredMethod("VFECore.DefExtensionActive:DoWork", new [] { AccessTools.TypeByName("Verse.TerrainDef") }),
         }.Where(x => x != null).ToHashSet();
 
         private static readonly HashSet<MethodInfo> NonTickingUpdateMethodCalls = new[]


### PR DESCRIPTION
Dropped patches for special terrain (it no longer uses the stopwatch) and hash code calls (the method that was unsafe got dropped, replaced with 2 safe ones).

Added extra System RNG patch. The method had System RNG before, but it was unused... It still is unused, but they added a second RNG usage.

Updated DebugActions to check Biomes! Core and VFE Core special terrain update methods.