### PR TITLE
Update Vanilla Expanded Framework

### DIFF
--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -996,7 +996,7 @@ namespace Multiplayer.Compat
         private static void PatchSpecialTerrain()
         {
             MpCompat.harmony.Patch(AccessTools.DeclaredMethod("VFECore.SpecialTerrainList:TerrainUpdate"),
-                prefix: new HarmonyMethod(typeof(BiomesCore), nameof(RemoveTerrainUpdateTimeBudget)));
+                prefix: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(RemoveTerrainUpdateTimeBudget)));
         }
 
         private static void RemoveTerrainUpdateTimeBudget(ref long timeBudget)
@@ -1015,12 +1015,24 @@ namespace Multiplayer.Compat
 
         private static Type weatherOverlayEffectsType;
         private static AccessTools.FieldRef<SkyOverlay, int> weatherOverlayEffectsNextDamageTickField;
+        private static AccessTools.FieldRef<SkyOverlay, Dictionary<Map, int>> weatherOverlayEffectsNextDamageTickForMapField;
 
         private static void PatchWeatherOverlayEffects()
         {
             // It'll likely have issues with async time, as there's only 1 timer for all maps.
             weatherOverlayEffectsType = AccessTools.TypeByName("VFECore.WeatherOverlay_Effects");
-            weatherOverlayEffectsNextDamageTickField = AccessTools.FieldRefAccess<int>(weatherOverlayEffectsType, "nextDamageTick");
+            var nextDamageTickField = AccessTools.DeclaredField(weatherOverlayEffectsType, "nextDamageTick");
+            var nextDamageTickForMapField = AccessTools.DeclaredField(weatherOverlayEffectsType, "nextDamageTickForMap");
+
+            if (nextDamageTickForMapField != null)
+                weatherOverlayEffectsNextDamageTickForMapField = AccessTools.FieldRefAccess<SkyOverlay, Dictionary<Map, int>>(nextDamageTickForMapField);
+            else if (nextDamageTickField != null)
+                weatherOverlayEffectsNextDamageTickField = AccessTools.FieldRefAccess<SkyOverlay, int>(nextDamageTickField);
+            else
+            {
+                Log.Error("VFECore.WeatherOverlay_Effects:nextDamageTick field, patch failed.");
+                return;
+            }
 
             MpCompat.harmony.Patch(AccessTools.DeclaredMethod(typeof(GameComponentUtility), nameof(GameComponentUtility.FinalizeInit)),
                 postfix: new HarmonyMethod(typeof(VanillaExpandedFramework), nameof(RefreshWeatherOverlayEffectCache)));
@@ -1039,7 +1051,12 @@ namespace Multiplayer.Compat
                 foreach (var overlay in def.Worker.overlays)
                 {
                     if (weatherOverlayEffectsType.IsInstanceOfType(overlay))
-                        weatherOverlayEffectsNextDamageTickField(overlay) = 0;
+                    {
+                        if (weatherOverlayEffectsNextDamageTickForMapField != null)
+                            weatherOverlayEffectsNextDamageTickForMapField(overlay).Clear();
+                        else
+                            weatherOverlayEffectsNextDamageTickField(overlay) = 0;
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Added support for a (potential) future update/fix to weather overlays (https://github.com/Vanilla-Expanded/VanillaExpandedFramework/pull/74)
- Fixed special terrain patch, made it use `VanillaExpandedFramework:RemoveTerrainUpdateTimeBudget` instead of `BiomesCore:RemoveTerrainUpdateTimeBudget` (otherwise, it'll break with #416)