### PR TITLE
Added `MethodOf` methods, changed C# lang version to 12

### DIFF
--- a/Source/MpMethodUtil.cs
+++ b/Source/MpMethodUtil.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
@@ -267,40 +266,19 @@ namespace Multiplayer.Compat
         /// <summary>
         /// <para>Taken from Fishery</para>
         /// <para>Original source: <see href="https://github.com/bbradson/Fishery/blob/af759661bdc404b85309ad5d8ca3d36607fc79d3/Source/FisheryLib/Aliases.cs#L18"/></para>
-        /// <para>More convenient than the alternative, but only works properly with static methods (returns delegate instead of the method).</para>
-        /// <para>Comparison between the two approaches: <see href="https://dotnetfiddle.net/Cmt774"/></para>
+        /// <para>This method will return a <see cref="MethodInfo"/> of a delegate which was passed in as an argument.</para>
+        /// <para>Only works on static methods. <see cref="SymbolExtensions"/> supports non-static method, but is less convenient and will return base method when trying to pass an overriden method.</para>
         /// </summary>
         /// <example>
         /// <code>
         /// var staticMethod = MethodOf(() => MethodOf(TestClass.TestStaticMethod);
         /// var staticMethodWithConflict = MethodOf(() => MethodOf(new Action&lt;int&gt;(TestClass.TestStaticMethodWithNameConflicts));
-        /// // Instance methods not supported, as it will return a delegate instead of the original method.
-        /// // Use the other MethodOf method or AccessTools to access those.
         /// </code>
         /// </example>
         /// <param name="method">The delegate from which to get the <see cref="MethodInfo"/> for.</param>
         /// <returns>The target method for the delegate.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static MethodInfo MethodOf(Delegate method) => method.Method;
-
-        /// <summary>
-        /// <para>Taken from Microsoft Bot Builder SDK V3</para>
-        /// <para>Original source: <see href="https://github.com/microsoft/BotBuilder-V3/blob/c5a89ce198e17441dd68ed3ffba0a6884f1d60dc/CSharp/Library/Microsoft.Bot.Builder/Base/Types.cs#L47-L51"/></para>
-        /// <para>Works with both static and non-static methods, however it's not as convenient as the alternative approach.</para>
-        /// <para>Comparison between the two approaches: <see href="https://dotnetfiddle.net/Cmt774"/></para>
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// var staticMethod = MethodOf(() => TestClass.TestStaticMethod());
-        /// var staticMethodWithConflict = MethodOf(() => TestClass.TestStaticMethodWithNameConflicts(default));
-        /// var instanceMethod = MethodOf(() => ((TestClass)null).TestInstanceMethod());
-        /// var instanceMethodWithConflicts = MethodOf(() => ((TestClass)null).TestInstanceMethodWithNameConflicts(default));
-        /// </code>
-        /// </example>
-        /// <param name="method">The expression from which to get the <see cref="MethodInfo"/> for.</param>
-        /// <returns>The method that was called by the expression.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static MethodInfo MethodOf(Expression<Action> method) => ((MethodCallExpression)method.Body).Method;
 
         #endregion
     }

--- a/Source/MpMethodUtil.cs
+++ b/Source/MpMethodUtil.cs
@@ -1,15 +1,19 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 using HarmonyLib;
 
 namespace Multiplayer.Compat
 {
-    // From Multiplayer.Client.Util
     public static class MpMethodUtil
     {
+        #region Lambdas
+
+        // From Multiplayer.Client.Util, modified to handle generics.
         const string DisplayClassPrefix = "<>c__DisplayClass";
         const string SharedDisplayClass = "<>c";
         const string LambdaMethodInfix = "b__";
@@ -255,5 +259,49 @@ namespace Multiplayer.Compat
             }
             return null;
         }
+
+        #endregion
+
+        #region MethodOf
+
+        /// <summary>
+        /// <para>Taken from Fishery</para>
+        /// <para>Original source: <see href="https://github.com/bbradson/Fishery/blob/af759661bdc404b85309ad5d8ca3d36607fc79d3/Source/FisheryLib/Aliases.cs#L18"/></para>
+        /// <para>More convenient than the alternative, but only works properly with static methods (returns delegate instead of the method).</para>
+        /// <para>Comparison between the two approaches: <see href="https://dotnetfiddle.net/Cmt774"/></para>
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var staticMethod = MethodOf(() => MethodOf(TestClass.TestStaticMethod);
+        /// var staticMethodWithConflict = MethodOf(() => MethodOf(new Action&lt;int&gt;(TestClass.TestStaticMethodWithNameConflicts));
+        /// // Instance methods not supported, as it will return a delegate instead of the original method.
+        /// // Use the other MethodOf method or AccessTools to access those.
+        /// </code>
+        /// </example>
+        /// <param name="method">The delegate from which to get the <see cref="MethodInfo"/> for.</param>
+        /// <returns>The target method for the delegate.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static MethodInfo MethodOf(Delegate method) => method.Method;
+
+        /// <summary>
+        /// <para>Taken from Microsoft Bot Builder SDK V3</para>
+        /// <para>Original source: <see href="https://github.com/microsoft/BotBuilder-V3/blob/c5a89ce198e17441dd68ed3ffba0a6884f1d60dc/CSharp/Library/Microsoft.Bot.Builder/Base/Types.cs#L47-L51"/></para>
+        /// <para>Works with both static and non-static methods, however it's not as convenient as the alternative approach.</para>
+        /// <para>Comparison between the two approaches: <see href="https://dotnetfiddle.net/Cmt774"/></para>
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var staticMethod = MethodOf(() => TestClass.TestStaticMethod());
+        /// var staticMethodWithConflict = MethodOf(() => TestClass.TestStaticMethodWithNameConflicts(default));
+        /// var instanceMethod = MethodOf(() => ((TestClass)null).TestInstanceMethod());
+        /// var instanceMethodWithConflicts = MethodOf(() => ((TestClass)null).TestInstanceMethodWithNameConflicts(default));
+        /// </code>
+        /// </example>
+        /// <param name="method">The expression from which to get the <see cref="MethodInfo"/> for.</param>
+        /// <returns>The method that was called by the expression.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static MethodInfo MethodOf(Expression<Action> method) => ((MethodCallExpression)method.Body).Method;
+
+        #endregion
     }
 }

--- a/Source/Multiplayer_Compat.csproj
+++ b/Source/Multiplayer_Compat.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <PublicizeAsReferenceAssemblies>false</PublicizeAsReferenceAssemblies>

--- a/Source_Referenced/Multiplayer_Compat_Referenced.csproj
+++ b/Source_Referenced/Multiplayer_Compat_Referenced.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>12</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <PublicizeAsReferenceAssemblies>false</PublicizeAsReferenceAssemblies>


### PR DESCRIPTION
The first `MethodOf` is taken from Fishery (but capitalized, as opposed to `methodof` in Fishery, and doesn't include global using). Link to the source provided in comments. **Do we need to include the copyright notice with it as well? (Mozilla Public License, v. 2.0)**

C# lang version needs to be 10+ for simple usage of Fishery's `MethodOf`, as otherwise it'll require typing more code, lowering the convenience of it.

~~The second `MethodOf` is taken from Microsoft Bot Builder SDK V3 (under MIT license). It's less convenient to use, but supports non-static methods without any issues. Link to the source provided in comments.~~

~~Comparison between the results of those 2 methods: https://dotnetfiddle.net/Cmt774~~

I've included those methods in `MpMethodUtil`, as the class seemed fitting in name. I've also added regions to the file, splitting to lambdas part and MethodOf part.