### PR TITLE
Update MpMethodUtil.GetMethod

### DIFF
--- a/Source/MpMethodUtil.cs
+++ b/Source/MpMethodUtil.cs
@@ -211,11 +211,16 @@ namespace Multiplayer.Compat
                     return AccessTools.DeclaredConstructor(type, args);
 
                 case MethodType.StaticConstructor:
-                    return Enumerable.FirstOrDefault(AccessTools
-                            .GetDeclaredConstructors(type), c => c.IsStatic);
-            }
+                    return AccessTools.GetDeclaredConstructors(type).FirstOrDefault(c => c.IsStatic);
 
-            return null;
+                case MethodType.Enumerator:
+                    if (methodName == null)
+                        return null;
+                    return AccessTools.EnumeratorMoveNext(AccessTools.DeclaredMethod(type, methodName, args));
+
+                default:
+                    return null;
+            }
         }
 
         /// <summary>Get the first method in the given type that matches the specified signature, return null if failed.</summary>


### PR DESCRIPTION
Changes:
- `MethodType.Enumerator` support using `AccessTools.EnumeratorMoveNext`
- Moved the final `return null` into the default case of the switch to stop the IDE from suggesting adding a default branch
- Use `Enumerable.FirstOrDefault` as extension method again (previously it was automatically changed by IDE due to conflict with `GenCollection.FirstOrDefault`)

As a side note, this could be updated again once Harmony 2.3 releases:
- Getter/Setter indexers using `AccessTools.IndexerGetter`/`AccessTools.IndexerSetter` (used when method name is null instead of returning null as we do right now)
- Another switch branch to support `MethodType.Async` using `AccessTools.AsyncMoveNext`