### PR TITLE
Fix warning

### DIFF
--- a/Source/DialogUtilities.cs
+++ b/Source/DialogUtilities.cs
@@ -91,7 +91,9 @@ namespace Multiplayer.Compat
         {
             if (isPauseLockInitialized) return;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             MP.RegisterPauseLock(IsPausingDialogOpen);
+#pragma warning restore CS0618 // Type or member is obsolete
             isPauseLockInitialized = true;
         }
 

--- a/Source/Mods/SimpleSidearms.cs
+++ b/Source/Mods/SimpleSidearms.cs
@@ -16,7 +16,7 @@ namespace Multiplayer.Compat
     {
         // TODO: Suggest the author to encapsulate this, would simplify things so much
         [MpCompatSyncField("SimpleSidearms.rimworld.CompSidearmMemory", "primaryWeaponMode")]
-        private static ISyncField primaryWeaponModeSyncField;
+        protected static ISyncField primaryWeaponModeSyncField;
 
         public SimpleSidearmsCompat(ModContentPack mod)
         {

--- a/Source/Mods/VanillaFactionsTribal.cs
+++ b/Source/Mods/VanillaFactionsTribal.cs
@@ -71,9 +71,9 @@ namespace Multiplayer.Compat
         // GameComponent_Tribals
         private static AccessTools.FieldRef<GameComponent> tribalsGameCompInstance;
         [MpCompatSyncField("VFETribals.GameComponent_Tribals", "ethos")]
-        private static ISyncField tribalsGameCompEthosField;
+        protected static ISyncField tribalsGameCompEthosField;
         [MpCompatSyncField("VFETribals.GameComponent_Tribals", "ethosLocked")]
-        private static ISyncField tribalsGameCompEthosLockedField;
+        protected static ISyncField tribalsGameCompEthosLockedField;
 
         // Window_CustomizeCornerstones
         private static Type customizeCornerstonesWindowType;


### PR DESCRIPTION
- Pause locks were made obsolete, but moving from them would require extra work and time - disabling warning for it.
- Fields marked with `MpCompatSyncField` are considered never assigned to if private or internal. Can be fixed by making them `public` or `protected` (including `private protected` and `internal protected`). Both `public` and `protected internal` would allow them to be accessed from other types, while `protected` and `private protected` would be basically identical (due to us never needing to make a subtype of any of our patch types).

The errors (copied from https://github.com/rwmt/Multiplayer-Compatibility/actions/runs/7771179784/job/21192189832)
```
Warning: /home/runner/work/Multiplayer-Compatibility/Multiplayer-Compatibility/Source/DialogUtilities.cs(94,13): warning CS0618: 'MP.RegisterPauseLock(PauseLockDelegate)' is obsolete: 'Use Session instead.' [/home/runner/work/Multiplayer-Compatibility/Multiplayer-Compatibility/Source/Multiplayer_Compat.csproj]
Warning: /home/runner/work/Multiplayer-Compatibility/Multiplayer-Compatibility/Source/Mods/VanillaFactionsTribal.cs(76,35): warning CS0649: Field 'VanillaFactionsTribal.tribalsGameCompEthosLockedField' is never assigned to, and will always have its default value null [/home/runner/work/Multiplayer-Compatibility/Multiplayer-Compatibility/Source/Multiplayer_Compat.csproj]
Warning: /home/runner/work/Multiplayer-Compatibility/Multiplayer-Compatibility/Source/Mods/SimpleSidearms.cs(19,35): warning CS0649: Field 'SimpleSidearmsCompat.primaryWeaponModeSyncField' is never assigned to, and will always have its default value null [/home/runner/work/Multiplayer-Compatibility/Multiplayer-Compatibility/Source/Multiplayer_Compat.csproj]
Warning: /home/runner/work/Multiplayer-Compatibility/Multiplayer-Compatibility/Source/Mods/VanillaFactionsTribal.cs(74,35): warning CS0649: Field 'VanillaFactionsTribal.tribalsGameCompEthosField' is never assigned to, and will always have its default value null [/home/runner/work/Multiplayer-Compatibility/Multiplayer-Compatibility/Source/Multiplayer_Compat.csproj]
```