### PR TITLE
Updated Alpha Prefabs CameraDriver.MapPosition patch

### DIFF
--- a/Source/Mods/AlphaPrefabs.cs
+++ b/Source/Mods/AlphaPrefabs.cs
@@ -98,7 +98,7 @@ namespace Multiplayer.Compat
             return DropCellFinder.TradeDropSpot(Find.CurrentMap);
         }
 
-        [MpCompatTranspiler("AlphaPrefabs.Window_Prefab", "OrderPrefab")]
+        [MpCompatTranspiler("AlphaPrefabs.Window_Prefab", "GetPosition")]
         private static IEnumerable<CodeInstruction> ReplaceCameraMapPosition(IEnumerable<CodeInstruction> instr, MethodBase baseMethod)
         {
             var target = AccessTools.PropertyGetter(typeof(CameraDriver), nameof(CameraDriver.MapPosition));


### PR DESCRIPTION
The use of map position was changed to a different method, so patch was changed to target it instead.