### PR TITLE
Update Biomes! Core compat

### DIFF
--- a/Source/Mods/BiomesCore.cs
+++ b/Source/Mods/BiomesCore.cs
@@ -51,11 +51,7 @@ namespace Multiplayer.Compat
                     "BiomesCore.GenSteps.ValleyPatch:Postfix",
                 }, false);
 
-                PatchingUtilities.PatchPushPopRand(new[]
-                {
-                    "BiomesCore.CompPlantReleaseSpore:ThrowPoisonSmoke",
-                    "BiomesCore.TerrainComp_MoteSpawner:ThrowMote",
-                });
+                PatchingUtilities.PatchPushPopRand("BiomesCore.CompPlantReleaseSpore:ThrowPoisonSmoke");
             }
         }
     }


### PR DESCRIPTION
One of the methods in the mod that we patched was removed in a recent update, so it ended up causing an error. It didn't cause any issues since it was the last thing patched, so this will just get rid of the error when launching.