### PR TITLE
Added compat for Vanilla Temperature Expanded

### DIFF
--- a/Source/Mods/VanillaTemperatureExpanded.cs
+++ b/Source/Mods/VanillaTemperatureExpanded.cs
@@ -1,0 +1,29 @@
+﻿using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat;
+
+/// <summary>Vanilla Temperature Expanded by Oskar Potocki, xrushha, Arquebus, Taranchuk</summary>
+/// <see href="https://github.com/Vanilla-Expanded/VanillaTemperatureExpanded"/>
+/// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=3202046258"/>
+[MpCompatFor("VanillaExpanded.Temperature")]
+public class VanillaTemperatureExpanded
+{
+    public VanillaTemperatureExpanded(ModContentPack mod)
+    {
+        LongEventHandler.ExecuteWhenFinished(LatePatch);
+
+        // Unlink/relink
+        MpCompat.RegisterLambdaDelegate("VanillaTemperatureExpanded.Comps.CompAcTempControl", nameof(ThingComp.CompGetGizmosExtra), 0);
+    }
+
+    private static void LatePatch()
+    {
+        var type = AccessTools.TypeByName("VanillaTemperatureExpanded.Buildings.Building_AcControlUnit");
+        // Change temperature by +/- 1/10 
+        MP.RegisterSyncMethod(type, "InterfaceChangeTargetNetworkTemperature");
+        // Reset temperature
+        MP.RegisterSyncMethodLambda(type, nameof(Thing.GetGizmos), 2);
+    }
+}


### PR DESCRIPTION
The compat required a new sync worker for Vanilla Expanded Framework (for `PipeNet`) - specifically, the link/unlink interaction. It could technically be achieved differently (don't sync the pipe net but get it from the `Thing`), but this was the simplest solution and could come in handy if we ever need to sync `PipeNet` again in the future.

Likely the last, or one of the last 1.4 PRs from me.