### PR TITLE
Update some of the mods that broke in 1.5 update

### DIFF
--- a/Source/Mods/Hospitality.cs
+++ b/Source/Mods/Hospitality.cs
@@ -49,10 +49,10 @@ namespace Multiplayer.Compat
         {
             // Cache
             {
-                var type = AccessTools.TypeByName("Hospitality.CompUtility");
+                var type = AccessTools.TypeByName("Hospitality.Utilities.CompUtility");
                 guestCompsField = AccessTools.StaticFieldRefAccess<IDictionary>(AccessTools.DeclaredField(type, "guestComps"));
 
-                type = AccessTools.TypeByName("Hospitality.RelationUtility");
+                type = AccessTools.TypeByName("Hospitality.Utilities.RelationUtility");
                 relationCacheField = AccessTools.StaticFieldRefAccess<IDictionary>(AccessTools.DeclaredField(type, "relationCache"));
 
                 type = AccessTools.TypeByName("Hospitality.Utilities.GenericUtility");
@@ -73,7 +73,7 @@ namespace Multiplayer.Compat
                 syncFields = AccessTools.StaticFieldRefAccess<ISyncField[]>(AccessTools.DeclaredField("Hospitality.Multiplayer:guestFields"));
 
                 // Basically an extension method to pawn.GetComp<CompGuest>, but with extra caching and null.
-                compGuestMethod = MethodInvoker.GetHandler(AccessTools.DeclaredMethod("Hospitality.CompUtility:CompGuest"));
+                compGuestMethod = MethodInvoker.GetHandler(AccessTools.DeclaredMethod("Hospitality.Utilities.CompUtility:CompGuest"));
 
                 // Hospitality starts watching in this DoHeader is called before DoCell, so it should be good enough of a place to put it in.
                 var type = AccessTools.TypeByName("Hospitality.MainTab.PawnColumnWorker_Relationship");

--- a/Source/Mods/RimFridge.cs
+++ b/Source/Mods/RimFridge.cs
@@ -1,49 +1,34 @@
-﻿using System;
-using System.Runtime.Serialization;
-using HarmonyLib;
+﻿using HarmonyLib;
 using Multiplayer.API;
 using Verse;
 
 namespace Multiplayer.Compat
 {
-    /// <summary>RimFridge by KiameV</summary>
+    /// <summary>RimFridge by KiameV, maintained by "Just Harry"</summary>
     /// <remarks>Fixes for gizmos</remarks>
-    /// <see href="https://github.com/KiameV/rimworld-rimfridge"/>
-    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1180721235"/>
+    /// <see href="https://github.com/just-harry/rimworld-rimfridge-now-with-shelves"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2898411376"/>
     [MpCompatFor("rimfridge.kv.rw")]
     public class RimFridgeCompat
     {
-        private static AccessTools.FieldRef<object, ThingComp> fridgeField;
-        private static Type dialogType;
-
         public RimFridgeCompat(ModContentPack mod)
         {
             // Several Gizmos
             {
-                MpCompat.RegisterLambdaDelegate("RimFridge.CompRefrigerator", "CompGetGizmosExtra", 1, 2, 3, 4, 5);
+                var type = AccessTools.TypeByName("RimFridge.CompRefrigerator");
+                // Offset temperature by x degrees
+                MP.RegisterSyncMethod(type, "InterfaceChangeTargetTemperature");
+                // Reset to default
+                MpCompat.RegisterLambdaDelegate(type, "CompGetGizmosExtra", 2);
+
+                // Toggle darklight
                 MpCompat.RegisterLambdaMethod("RimFridge.CompToggleGlower", "CompGetGizmosExtra", 0);
-
-                dialogType = AccessTools.TypeByName("RimFridge.Dialog_RenameFridge");
-                fridgeField = AccessTools.FieldRefAccess<ThingComp>(dialogType, "fridge");
-
-                MP.RegisterSyncWorker<object>(SyncFridgeName, dialogType);
-                MP.RegisterSyncMethod(dialogType, "SetName");
             }
 
             // Current map usage
+            // Not needed for the fork made by "Not Harry" (at the moment, the only 1.5 fork), but other forks may need this.
             {
-                PatchingUtilities.ReplaceCurrentMapUsage("RimFridge.Patch_ReachabilityUtility_CanReach:Prefix");
-            }
-        }
-
-        private static void SyncFridgeName(SyncWorker sync, ref object dialog)
-        {
-            if (sync.isWriting)
-                sync.Write(fridgeField(dialog));
-            else
-            {
-                dialog = FormatterServices.GetUninitializedObject(dialogType);
-                fridgeField(dialog) = sync.Read<ThingComp>();
+                PatchingUtilities.ReplaceCurrentMapUsage("RimFridge.Patch_ReachabilityUtility_CanReach:Prefix", false);
             }
         }
     }

--- a/Source_Referenced/VanillaFactionsDeserters.cs
+++ b/Source_Referenced/VanillaFactionsDeserters.cs
@@ -1,5 +1,4 @@
-﻿#if false
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -80,7 +79,7 @@ namespace Multiplayer.Compat
                 // Re-cache intel amount
                 // Since we change how it's handled by allowing players to open the dialog locally without forcing pause,
                 // we need to re-cache the value in case it ends up changing due to decay/other player actions.
-                MpCompat.harmony.Patch(AccessTools.DeclaredMethod(typeof(Dialog_DeserterNetwork), nameof(Dialog_Debug.DoWindowContents)),
+                MpCompat.harmony.Patch(AccessTools.DeclaredMethod(typeof(Dialog_DeserterNetwork), nameof(Dialog_DeserterNetwork.DoWindowContents)),
                     prefix: new HarmonyMethod(typeof(VanillaFactionsDeserters), nameof(PreDeserterNetworkDraw)));
 
                 #endregion
@@ -548,4 +547,3 @@ namespace Multiplayer.Compat
         #endregion
     }
 }
-#endif


### PR DESCRIPTION
Hospitality:
- Some types were moved from `Hospitality` to `Hospitality.Utilities` namespace

Vanilla Factions Expanded - Deserters:
- Changed `nameof(Dialog_Debug.DoWindowContents)` to  `nameof(Dialog_DeserterNetwork.DoWindowContents)`, as it was supposed to be

RimFridge:
- Removed anything related to rename dialog, as renaming was changed in 1.5
  - The syncing of renaming should be possible to handle in a somewhat universal matter by MP itself - rwmt/Multiplayer#443.
- Updated links to point to a fork by "Just Harry", as it's the most up-to-date version
- Changed the current map patch to not long patching failures
  - Some RimFridge forks don't have the current map issue, like the one by "Just Harry" - however, the patch is kept for forks that do need it

PatchingUtilities:
- Modified to allow for current map patch to be applied without logging patching failures

There's a few other mods using rename dialog that will need patching, but aren't updated yet (like Compositable Loadouts)