### PR TITLE
Fix and update Vanilla Expanded mods for 1.5

### DIFF
--- a/Source/Mods/VanillaEventsExpanded.cs
+++ b/Source/Mods/VanillaEventsExpanded.cs
@@ -20,16 +20,13 @@ namespace Multiplayer.Compat
                 "VEE.RegularEvents.CaravanAnimalWI:GenerateGroup",
                 "VEE.RegularEvents.MeteoriteShower:TryExecuteWorker",
                 "VEE.RegularEvents.WeaponPod:TryExecuteWorker",
+                "VEE.RegularEvents.EarthQuake:DamageInRadius",
             };
 
             PatchingUtilities.PatchSystemRand(methodsForAll, false);
-            // This method only calls other methods that use RNG calls
-            PatchingUtilities.PatchPushPopRand("VEE.RegularEvents.EarthQuake:TryExecuteWorker");
-            // Only patch System.Random out, as this methods is only called by other ones
-            PatchingUtilities.PatchSystemRand("VEE.RegularEvents.EarthQuake:DamageInRadius", false);
 
             // Unity RNG
-            PatchingUtilities.PatchUnityRand("VEE.Shuttle:Tick");
+            PatchingUtilities.PatchUnityRand("VEE.Shuttle:Tick", false);
 
             // Current map usage, picks between rain and snow based on current map temperature, instead of using map it affects
             PatchingUtilities.ReplaceCurrentMapUsage("VEE.PurpleEvents.PsychicRain:ForcedWeather");

--- a/Source/Mods/VanillaExpandedFramework.cs
+++ b/Source/Mods/VanillaExpandedFramework.cs
@@ -23,13 +23,13 @@ namespace Multiplayer.Compat
         public VanillaExpandedFramework(ModContentPack mod)
         {
             (Action patchMethod, string componentName, bool latePatch)[] patches =
-            {
+            [
                 (PatchItemProcessor, "Item Processor", false),
                 (PatchOtherRng, "Other RNG", false),
                 (PatchVFECoreDebug, "Debug Gizmos", false),
                 (PatchAbilities, "Abilities", true),
                 (PatchHireableFactions, "Hireable Factions", false),
-                (PatchVanillaFurnitureExpanded, "Vanilla Furniture Expanded", false),
+                (PatchVanillaFurnitureExpanded, "Vanilla Furniture Expanded", true),
                 (PatchVanillaFactionMechanoids, "Vanilla Faction Mechanoids", false),
                 (PatchAnimalBehaviour, "Animal Behaviour", false),
                 (PatchExplosiveTrialsEffect, "Explosive Trials Effect", false),
@@ -47,21 +47,30 @@ namespace Multiplayer.Compat
                 (PatchExtraPregnancyApproaches, "Extra Pregnancy Approaches", false),
                 (PatchWorkGiverDeliverResources, "Building stuff requiring non-construction skill", false),
                 (PatchExpandableProjectile, "Expandable projectile", false),
-            };
+            ];
 
             foreach (var (patchMethod, componentName, latePatch) in patches)
             {
-                try
+                if (latePatch)
+                    LongEventHandler.ExecuteWhenFinished(ApplyPatch);
+                else
+                    ApplyPatch();
+
+                void ApplyPatch()
                 {
-                    if (latePatch)
-                        LongEventHandler.ExecuteWhenFinished(patchMethod);
-                    else
+                    try
+                    {
+#if DEBUG
+                        Log.Message($"Patching Vanilla Expanded Framework - {componentName}");
+#endif
+
                         patchMethod();
-                }
-                catch (Exception e)
-                {
-                    Log.Error($"Encountered an error patching {componentName} part of Vanilla Expanded Framework - this part of the mod may not work properly!");
-                    Log.Error(e.ToString());
+                    }
+                    catch (Exception e)
+                    {
+                        Log.Error($"Encountered an error patching {componentName} part of Vanilla Expanded Framework - this part of the mod may not work properly!");
+                        Log.Error(e.ToString());
+                    }
                 }
             }
         }

--- a/Source/Mods/VanillaFurnitureExpandedSecurity.cs
+++ b/Source/Mods/VanillaFurnitureExpandedSecurity.cs
@@ -49,14 +49,7 @@ namespace Multiplayer.Compat
 
             // RNG fix
             {
-                var methods = new[]
-                {
-                    "VFESecurity.Building_Shield:Notify_EnergyDepleted",
-                    "VFESecurity.Building_Shield:Draw",
-                };
-
-                PatchingUtilities.PatchPushPopRand(AccessTools.Method("VFESecurity.Building_Shield:AbsorbDamage", new[] { typeof(float), typeof(DamageDef), typeof(float) }));
-                PatchingUtilities.PatchPushPopRand(methods);
+                PatchingUtilities.PatchPushPopRand("VFESecurity.Building_Shield:DrawAt");
             }
         }
 


### PR DESCRIPTION
This should fix the issues I've found so far, along with a handful of changes/improvements.

Vanilla Expanded Framework:
- Slightly modified the modular patching
  - Changed where the patch method is called, so it'll include the try/catch block in late patches as well
  - Added a message log behind (for debug builds only) that will log what is being patched before applying the patch
- Vanilla Furniture Expanded patch was moved to late patch to prevent issues due to the mod accessing DefOfs in the patched methods

Vanilla Events Expanded:
- Stopped pushing/popping the RNG state where it's not needed
  - I've originally made those patches when I didn't fully understand how MP and RimWorld work, so I assumed that those would be needed

Vanilla Factions Expanded - Empire:
- Added a null map check to the quest generation
  - This is an issue with the mod itself which will happen if `TestRun` method is called for a faction without maps (https://github.com/Vanilla-Expanded/VanillaFactionsExpanded-Empire/pull/8)
  - After deeper investigation I've realized it always happens in MP due to MP's `FactionRepeater` trying to repeat a quest generation for all factions, including spectator faction (which doesn't have any maps)

Vanilla Furniture Expanded - Security:
- Stopped pushing/popping the RNG state where it's not needed
  - Same reason as for Vanilla Events Expanded
- Changed patch target from `Draw` to `DrawAt`

Vanilla Psycasts Expanded:
- Changed the patching to work similar as Vanilla Expanded Framework - made it modular so if a single module fails then it won't break everything after it
- Removed an empty method (PatchCurrentMapUsage)
- Renamed PatchGizmosAndFlecks to PatchMotesAndFlecks
- Slightly reorganized where some of the patches are
- Completely reworked psyset renaming code (won't do anything meaningful until mering https://github.com/rwmt/Multiplayer/pull/443)
  - Added `Dialog_RenamePsysetMp` class, which will handle renaming and allow MP to sync it
  - Added `PsysetRenameHolder` class, which hold the psyset and psycasting hediff and will be used for syncing psysets
    - We cannot sync psysets by themselves as they don't store any reference to their parent, and we need a workaround by using the hediff to sync them
  - Changed psycasting ITab code to create our rename dialog instead of the VPE one, as well as making the code pass the hediff to the constructor