### PR TITLE
Update and fix cache clearing, fixes #446

### DIFF
--- a/Source/MpCompatLoader.cs
+++ b/Source/MpCompatLoader.cs
@@ -92,13 +92,14 @@ namespace Multiplayer.Compat
             // GenTypes.ClearCache() on its own won't work, as MP isn't doing anything when it's called.
             var mpType = AccessTools.TypeByName("Multiplayer.Client.Util.TypeCache") ?? AccessTools.TypeByName("Multiplayer.Client.Multiplayer");
             ((IDictionary)AccessTools.Field(mpType, "subClasses").GetValue(null)).Clear();
+            ((IDictionary)AccessTools.Field(mpType, "subClassesOrdered").GetValue(null)).Clear();
             ((IDictionary)AccessTools.Field(mpType, "subClassesNonAbstract").GetValue(null)).Clear();
             ((IDictionary)AccessTools.Field(mpType, "interfaceImplementations").GetValue(null)).Clear();
             ((IDictionary)AccessTools.Field(mpType, "interfaceImplementationsOrdered").GetValue(null)).Clear();
             AccessTools.Method(mpType, "CacheTypeHierarchy").Invoke(null, []);
 
-            // Clear/re-init the list of ISyncSimple implementations.
-            AccessTools.Method("Multiplayer.Client.ImplSerialization:Init").Invoke(null, []);
+            // Clear/re-init the list of ISyncSimple implementations and Session subclasses.
+            AccessTools.Method("Multiplayer.Client.ApiSerialization:Init").Invoke(null, []);
             // Clear/re-init the localDefInfos dictionary so it contains the classes added from referenced assembly.
             AccessTools.Method("Multiplayer.Client.MultiplayerData:CollectDefInfos").Invoke(null, []);
         }


### PR DESCRIPTION
`Multiplayer.Client.ImplSerialization:Init` caches different (and more) stuff now. The data that we needed to re-cache (list of ISyncSimple implementations and since recently Session subclasses) is now handled in `Multiplayer.Client.ApiSerialization`.

On top of that, I've also added clearing of `subClassesOrdered` dictionary in `Multiplayer.Client.Util.TypeCache` to clear all the dictionaries before re-caching (as it was the only one that wasn't cleared, which I assume was due to it being added to MP after the cache clearing was made here).