### PR TITLE
Fix issues caused by HugsLib long events

### DIFF
--- a/Source/Mods/HugsLib.cs
+++ b/Source/Mods/HugsLib.cs
@@ -1,0 +1,16 @@
+﻿using Verse;
+
+namespace Multiplayer.Compat;
+
+/// <summary>HugsLib by UnlimitedHugs</summary>
+/// <see href="https://github.com/UnlimitedHugs/RimworldHugsLib"/>
+/// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=818773962"/>
+[MpCompatFor("UnlimitedHugs.HugsLib")]
+public class HugsLib
+{
+    public HugsLib(ModContentPack mod)
+    {
+        // Stop the long event from running when it could break stuff.
+        PatchingUtilities.CancelCallIfLongEventsAreUnsafe("HugsLib.HugsLibController:OnMapInitFinalized");
+    }
+}

--- a/Source/Mods/PerspectiveOres.cs
+++ b/Source/Mods/PerspectiveOres.cs
@@ -10,28 +10,19 @@ namespace Multiplayer.Compat
     [MpCompatFor("Owlchemist.PerspectiveOres")]
     public class PerspectiveOres
     {
-        private static bool allowedToRun = true;
-
         public PerspectiveOres(ModContentPack mod)
         {
-            // Patch to MP to mark when to stop long events Perspective: Ores
-            MpCompat.harmony.Patch(AccessTools.DeclaredMethod("Multiplayer.Client.SaveLoad:LoadInMainThread"),
-                prefix: new HarmonyMethod(typeof(PerspectiveOres), nameof(SetDisallowedToRun)),
-                finalizer: new HarmonyMethod(typeof(PerspectiveOres), nameof(SetAllowedToRun)));
+            PatchingUtilities.PatchLongEventMarkers();
 
             // Stop the "ProcessMap" from running when it could break stuff.
             MpCompat.harmony.Patch(AccessTools.DeclaredMethod("PerspectiveOres.PerspectiveOresSetup:ProcessMap"),
                 prefix: new HarmonyMethod(typeof(PerspectiveOres), nameof(StopSecondHostCall)));
         }
 
-        private static void SetDisallowedToRun() => allowedToRun = false;
-
-        private static void SetAllowedToRun() => allowedToRun = true;
-
         private static bool StopSecondHostCall(bool reset)
         {
             // Stop the host from running it for the second time. It messes stuff up due to the place it's called from.
-            if (!allowedToRun)
+            if (!PatchingUtilities.AllowedToRunLongEvents)
                 return false;
             // Prevent it from being called due to settings change, could mess stuff up.
             if (reset && MP.IsInMultiplayer)


### PR DESCRIPTION
I've moved the long event patch from Perspective: Ores to `PatchingUtilities` and applied it to HugsLib as well.