### PR TITLE
Updated Alpha mods

### DIFF
--- a/Source/Mods/AlphaAnimals.cs
+++ b/Source/Mods/AlphaAnimals.cs
@@ -19,21 +19,10 @@ namespace Multiplayer.Compat
                     "AlphaBehavioursAndEvents.Hediff_Crushing",
 
                     // Ocular plant conversion
-                    "AlphaBehavioursAndEvents.CompAbilityOcularConversion",
                     "AlphaBehavioursAndEvents.Gas_Ocular",
                 };
 
                 PatchingUtilities.PatchSystemRandCtor(rngFixConstructors, false);
-
-                var rngFixMethods = new[] //System.Random fixes
-                {
-                    "AlphaBehavioursAndEvents.Hediff_Crushing:RandomFilthGenerator",
-
-                    // Ocular plant conversion
-                    "AlphaBehavioursAndEvents.CompAbilityOcularConversion:Apply",
-                    "AlphaBehavioursAndEvents.Gas_Ocular:Tick",
-                };
-                PatchingUtilities.PatchPushPopRand(rngFixMethods);
 
                 var fixSystemRngMethods = new[]
                 {

--- a/Source/Mods/AlphaGenes.cs
+++ b/Source/Mods/AlphaGenes.cs
@@ -18,6 +18,9 @@ namespace Multiplayer.Compat
                 PatchingUtilities.PatchSystemRandCtor("AlphaGenes.CompAbilityOcularConversion", false);
                 PatchingUtilities.PatchSystemRand("AlphaGenes.CompInsanityBlast:Apply", false);
                 PatchingUtilities.PatchSystemRand("AlphaGenes.HediffComp_Parasites:Hatch", false);
+                // The following method is seeded, so it should be fine
+                // If not, then patching it as well should fix it
+                //"AlphaGenes.GameComponent_RandomMood:GameComponentTick",
             }
 
             // Abilities

--- a/Source/Mods/AlphaMechs.cs
+++ b/Source/Mods/AlphaMechs.cs
@@ -12,12 +12,6 @@ namespace Multiplayer.Compat
     {
         public AlphaMechs(ModContentPack mod)
         {
-            // Fix the mod using Find.CurrentMap instead of parent.Map - in both cases it creates new lord job on current (instead of parent) map
-            // Change mech to a vanilla one if the mod mechanoid is disabled
-            PatchingUtilities.ReplaceCurrentMapUsage("AlphaMechs.CompChangeDef:CompTick");
-            // Hediff runs out and mech turns back hostile
-            PatchingUtilities.ReplaceCurrentMapUsage("AlphaMechs.HediffComp_DeleteAfterTime:CompPostTick");
-
             // Gizmos
             MP.RegisterSyncMethod(AccessTools.DeclaredMethod("AlphaMechs.Pawn_HemogenVat:EjectContents"));
         }

--- a/Source/Mods/AlphaMemes.cs
+++ b/Source/Mods/AlphaMemes.cs
@@ -17,6 +17,7 @@ namespace Multiplayer.Compat
         {
             PatchingUtilities.PatchSystemRand("AlphaMemes.AlphaMemes_DamageWorker_AddInjury_Apply_Patch:SendHistoryIfMelee", false);
             PatchingUtilities.PatchPushPopRand("AlphaMemes.RitualBehaviorWorker_FuneralFramework:TryExecuteOn");
+            PatchingUtilities.PatchSystemRandCtor("AlphaMemes.CompAbilityOcularConversion");
             // The following method is seeded, so it should be fine
             // If not, then patching it as well should fix it
             //"AlphaMemes.GameComponent_RandomMood:GameComponentTick",


### PR DESCRIPTION
Alpha Animals:
- Fix errors due to patches to `CompAbilityOcularConversion`
  - The type was removed, causing the patches to fail
- Remove Push/Pop RNG patches
  - I've added them when I originally started working on MP, thinking they were needed - they aren't (and I've tested to make sure)

Alpha Genes:
- Added a note about safe (seeded) System.Random call
  - This matches the note in Alpha Memes
  - The type didn't exist when MP patch for it was last updated, so I didn't include a note back then

Alpha Mechs:
- Removed current map usage patches
  - The issue was fixed in Alpha Mechs (https://github.com/juanosarg/AlphaMechs/pull/3)

Alpha Memes:
- Added patch for `CompAbilityOcularConversion`
  - This type was likely moved here from Alpha Animals

From my testing, it didn't seem like other Alpha mods didn't need updates.