### PR TITLE
Fix/update RPG Style Inventory

### DIFF
--- a/Source/Mods/RPGStyleInventory.cs
+++ b/Source/Mods/RPGStyleInventory.cs
@@ -16,30 +16,36 @@ namespace Multiplayer.Compat
     [MpCompatFor("Sandy.RPGStyleInventory.avilmask.Revamped")]
     class RPGStyleInventory
     {
+        private static Type tabType;
+
         public RPGStyleInventory(ModContentPack mod)
         {
-            Type type = AccessTools.TypeByName("Sandy_Detailed_RPG_Inventory.Sandy_Detailed_RPG_GearTab");
-            
-            MP.RegisterSyncWorker<ITab_Pawn_Gear>(SyncITab, type);
-            MP.RegisterSyncMethod(type, "InterfaceDrop").SetContext(SyncContext.MapSelected);
-            MP.RegisterSyncMethod(type, "InterfaceIngest").SetContext(SyncContext.MapSelected);
+            tabType = AccessTools.TypeByName("Sandy_Detailed_RPG_Inventory.Sandy_Detailed_RPG_GearTab");
+
+            MP.RegisterSyncWorker<ITab_Pawn_Gear>(SyncITab, tabType);
+
+            // Original re-implemented InterfaceDrop/InterfaceIngest, but some stopped doing that.
+            // Sync those methods if they're declared, but skip if they aren't since we don't want
+            // to sync vanilla methods (which are already synced). On top of that, vanilla marked
+            // InterfaceIngest as obsolete (use FoodUtility.IngestFromInventoryNow instead),
+            // so avoid HugsLib warnings about patching obsolete methods.
+            foreach (var methodName in new[] { "InterfaceDrop", "InterfaceIngest" })
+            {
+                var method = AccessTools.DeclaredMethod(tabType, methodName);
+                if (method != null)
+                    MP.RegisterSyncMethod(method).SetContext(SyncContext.MapSelected);
+            }
 
             // Remove/add forced apparel
             if (mod.PackageId == "Sandy.RPGStyleInventory.avilmask.Revamped".ToLower()) {
-                MpCompat.RegisterLambdaDelegate(type, "PopupMenu", 1, 2);
+                MpCompat.RegisterLambdaDelegate(tabType, "PopupMenu", 0, 1);
             }
         }
 
         private static void SyncITab(SyncWorker sync, ref ITab_Pawn_Gear gearITab)
         {
-            if (sync.isWriting)
-            {
-                sync.Write(gearITab.GetType());
-            }
-            else
-            {
-                gearITab = (ITab_Pawn_Gear)InspectTabManager.GetSharedInstance(sync.Read<Type>());
-            }
+            if (!sync.isWriting)
+                gearITab = Activator.CreateInstance(tabType) as ITab_Pawn_Gear;
         }
     }
 }


### PR DESCRIPTION
- Changed ITab sync worker (`SyncITab`) to no longer send any data
  - Since we only ever expect 1 ITab type, it is now cached and used to construct it, rather than syncing the type and retrieving the ITab after syncing
  - It's handled (almost) the same way as MP handles basically any vanilla ITab (MP can just call the constructor directly since it can reference those)
- Only sync methods `InterfaceDrop` and `InterfaceIngest` if they exist and are declared in the type itself
  - This change is mostly relevant for RPG Style Inventory Revamped, which removed `InterfaceIngest` method (matching planned vanilla pawn gear ITab changes) - So far the vanilla method was marked as obsolete, and will be removed in a future version
  - This change will prevent us from syncing vanilla ITab methods, one of which is already synced by MP
  - This will prevent HugsLib warnings about MP patching obsolete methods (`InterfaceIngest`)
- Change lambda ordinals for popup menu patches (RPG Style Inventory Revamped only)
  - This fixes remove/add forced apparel
  - This also fixes force dropping items from the popup menu, which didn't work properly as the method which wasn't supposed to be synced ended up being synced