### PR TITLE
Fix RimFridge warnings

### DIFF
--- a/Source/Mods/RimFridge.cs
+++ b/Source/Mods/RimFridge.cs
@@ -28,7 +28,7 @@ namespace Multiplayer.Compat
             // Current map usage
             // Not needed for the fork made by "Not Harry" (at the moment, the only 1.5 fork), but other forks may need this.
             {
-                PatchingUtilities.ReplaceCurrentMapUsage("RimFridge.Patch_ReachabilityUtility_CanReach:Prefix", false);
+                PatchingUtilities.ReplaceCurrentMapUsage("RimFridge.Patch_ReachabilityUtility_CanReach:Prefix", false, false);
             }
         }
     }

--- a/Source/PatchingUtilities.cs
+++ b/Source/PatchingUtilities.cs
@@ -369,7 +369,7 @@ namespace Multiplayer.Compat
             }
         }
 
-        public static void ReplaceCurrentMapUsage(string typeColonName, bool logIfNothingPatched = true)
+        public static void ReplaceCurrentMapUsage(string typeColonName, bool logIfNothingPatched = true, bool logIfMissingMethod = true)
         {
             if (typeColonName.NullOrEmpty())
             {
@@ -379,12 +379,12 @@ namespace Multiplayer.Compat
 
             var method = AccessTools.DeclaredMethod(typeColonName) ?? AccessTools.Method(typeColonName);
             if (method != null)
-                ReplaceCurrentMapUsage(method, logIfNothingPatched);
-            else
+                ReplaceCurrentMapUsage(method, logIfNothingPatched, logIfMissingMethod);
+            else if (logIfMissingMethod)
                 Log.Warning($"Trying to patch current map usage for null method ({typeColonName}). Was the method removed or renamed?");
         }
 
-        public static void ReplaceCurrentMapUsage(MethodBase method, bool logIfNothingPatched = true)
+        public static void ReplaceCurrentMapUsage(MethodBase method, bool logIfNothingPatched = true, bool logIfMissingMethod = true)
         {
             if (method != null)
             {
@@ -394,7 +394,7 @@ namespace Multiplayer.Compat
 
                 MpCompat.harmony.Patch(method, transpiler: transpiler);
             }
-            else
+            else if (logIfMissingMethod)
                 Log.Warning("Trying to patch current map usage for null method. Was the method removed or renamed?");
         }
 


### PR DESCRIPTION
Changed current map usage patches to accept another argument (`logIfMissingMethod`) which, if true, will stop warnings about missing methods.

Changed RimFridge to set this argument to true, stopping warning. The patch is kept for RimFridge forks that haven't fixed this bug (currently the only 1.5 fork has this issue fixed, but there may be a new ones in the future).