### PR TITLE
Target .NET Framework 4.8

### DIFF
--- a/Source/Multiplayer_Compat.csproj
+++ b/Source/Multiplayer_Compat.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <LangVersion>12</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>

--- a/Source_Referenced/Multiplayer_Compat_Referenced.csproj
+++ b/Source_Referenced/Multiplayer_Compat_Referenced.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
     <LangVersion>12</LangVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>


### PR DESCRIPTION
Targeting .NET Framework 4.8 is required if we want to reference a .dll built targeting it, which will be necessary in the future for some referenced mods (for example, "A RimWorld of Magic").

As a side note, I started changing the patch for "A RimWorld of Magic" to be a referenced one. So far it allowed me to significantly simplify it and made the patch more readable, and it allowed me to condense the current patch at least 100 lines. I still expect the size of the patch to still go significantly up, possibly reaching 1000+ lines in total. In size alone it'll likely only be outdone by Vehicle Framework and Vanilla Expanded Framework.