### PR TITLE
Update Alpha Animals, reformat class, fix errors

### DIFF
--- a/Source/Mods/AlphaAnimals.cs
+++ b/Source/Mods/AlphaAnimals.cs
@@ -1,4 +1,7 @@
-﻿using Verse;
+﻿using System.Reflection;
+using HarmonyLib;
+using Multiplayer.API;
+using Verse;
 
 namespace Multiplayer.Compat
 {
@@ -7,11 +10,22 @@ namespace Multiplayer.Compat
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1541721856"/>
     /// contribution to Multiplayer Compatibility by Reshiram and Sokyran
     [MpCompatFor("sarg.alphaanimals")]
-    class AlphaBehavioursAndEvents
+    class AlphaAnimals
     {
-        public AlphaBehavioursAndEvents(ModContentPack mod)
+        #region Fields
+
+        private static MethodBase unsafeMethod;
+
+        #endregion
+
+        #region Main patch
+
+        public AlphaAnimals(ModContentPack mod)
         {
-            //RNG Fix
+            LongEventHandler.ExecuteWhenFinished(LatePatch);
+
+            #region RNG
+
             {
                 var rngFixConstructors = new[]
                 {
@@ -32,6 +46,61 @@ namespace Multiplayer.Compat
                 };
                 PatchingUtilities.PatchSystemRand(fixSystemRngMethods, false);
             }
+
+            #endregion
+
+            #region MP unsafe method patching
+
+            // Only apply if VFE-I2 is inactive.
+            // Need to check for _steam due to RW bug when
+            // running a workshop version while a local
+            // copy of a mod is active.
+            if (!ModsConfig.IsActive("OskarPotocki.VFE.Insectoid2") && !ModsConfig.IsActive("OskarPotocki.VFE.Insectoid2_steam"))
+            {
+                unsafeMethod = AccessTools.DeclaredMethod("AlphaBehavioursAndEvents.BlackCocoon:Tick");
+
+                // Make sure the method actually exists
+                if (unsafeMethod != null)
+                    MpCompat.harmony.Patch(AccessTools.DeclaredMethod("Multiplayer.Client.Extensions:PatchMeasure"),
+                        prefix: new HarmonyMethod(DontPatchUnsafeMethods));
+            }
+
+            #endregion
         }
+
+        private static void LatePatch()
+        {
+            #region Gizmos
+
+            {
+                // Detonate.
+                // Unused in 1.4 (code moved to Alpha Memes), so it could potentially
+                // be removed in the future. Include a null method check.
+                var method = AccessTools.DeclaredMethod($"AlphaBehavioursAndEvents.Pawn_Detonator:{nameof(Pawn.GetGizmos)}");
+                if (method != null)
+                    MP.RegisterSyncMethodLambda(method.DeclaringType, method.Name, 0);
+            }
+
+            #endregion
+        }
+
+        #endregion
+
+        #region MP unsafe method patching
+
+        private static bool DontPatchUnsafeMethods(MethodBase original)
+        {
+            // Multiplayer patches all ticking methods for any Thing
+            // subtype. Alpha Animals uses methods from Vanilla
+            // Factions Expanded - Insectoids 2, which (if that mod
+            // is not loaded) will cause an exception when attempting
+            // to patch that mod. We cannot patch VFE-I2 method
+            // directly, as that is specifically the issue MP itself
+            // is encountering, so we have to prevent MP from patching
+            // that method to make sure that it can load correctly.
+            return original != unsafeMethod;
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Updated Alpha Animals compat:

- Fixed an error that broke Multiplayer itself
  - This only happened when Vanilla Factions Expanded - Insectoids 2 was NOT active
  - The issue happens due to AA including a building that in its ticking method references VFE-I2 assembly - which caused generic MP patches to fail
  - The fix is to patch MP and prevent it from applying its patches to that particular method
    - This only happens if VFE-I2 is inactive
    - There's also an additional check to make sure the method exists before applying any patches - We're unable to patch the mod itself to remove those references since any attempts at patching that method will cause an exception
- Renamed the class from `AlphaBehavioursAndEvents` to `AlphaAnimals`
  - The file was already named `AlphaAnimals`
- Add regions to the file
- Synced a gizmo
  - Technically it's unused in 1.4 (the class was copied over to Alpha Memes and is used there), but was patched just in case