### PR TITLE
Fix issues with MpCompatSyncFieldAttribute

### DIFF
--- a/Source/MpCompatAttributes.cs
+++ b/Source/MpCompatAttributes.cs
@@ -468,9 +468,9 @@ namespace Multiplayer.Compat
                 if (field != null)
                     return field;
 
-                field = AccessTools.DeclaredField(Type, fieldName);
+                field = AccessTools.Field(Type, fieldName);
                 if (field == null)
-                    throw new MissingMethodException($"Couldn't find field {field} in type {Type}");
+                    throw new MissingFieldException($"Couldn't find field {fieldName} in type {Type}");
 
                 return field;
             }


### PR DESCRIPTION
Fixes:
- The field is accessed `AccessTools.Field` rather than `AccessTools.DeclaredField`
- The thrown exception if the `field` is null is now `MissingFieldException` rather than `MissingMethodException`
- The exception that's thrown if the `field` is null now uses `fieldName` rather than `field` in its message