### PR TITLE
Allow for multiple MpCompatSyncWorkerAttribute on same method

### DIFF
--- a/Source/MpCompatAttributes.cs
+++ b/Source/MpCompatAttributes.cs
@@ -495,7 +495,7 @@ namespace Multiplayer.Compat
             => this.instancePath = instancePath;
     }
 
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     [MeansImplicitUse(ImplicitUseTargetFlags.WithMembers)]
     public class MpCompatSyncWorkerAttribute : Attribute
     {


### PR DESCRIPTION
There isn't anything preventing us from doing that normally, and we do that in some situations - especially for empty (and `shouldConstruct` only) sync workers.