### PR TITLE
Updated and fixed `ReplaceMethod`

### DIFF
--- a/Source_Referenced/ARimWorldOfMagic.cs
+++ b/Source_Referenced/ARimWorldOfMagic.cs
@@ -814,7 +814,7 @@ public class ARimWorldOfMagic
             new CodeInstruction(OpCodes.Ldloc_0),
         ];
 
-        return instr.ReplaceMethod(target, replacement, baseMethod, ExtraInstructions, 1, "+");
+        return instr.ReplaceMethod(target, replacement, baseMethod, ExtraInstructions, null, 1, "+");
     }
 
     [MpCompatTranspiler(typeof(MagicCardUtility), nameof(MagicCardUtility.DrawLevelBar))]
@@ -859,7 +859,7 @@ public class ARimWorldOfMagic
         // Shouldn't happen
         else throw new Exception($"Trying to apply transpiler ({nameof(UniversalReplaceLevelUpPlusButton)}) for an unsupported type ({baseMethod.DeclaringType.FullDescription()}).");
         
-        return instr.ReplaceMethod(target, replacement, baseMethod, extraInstructions, expected, "+");
+        return instr.ReplaceMethod(target, replacement, baseMethod, extraInstructions, null, expected, "+");
     }
 
     #endregion
@@ -1123,9 +1123,9 @@ public class ARimWorldOfMagic
         ];
 
         // Replace the "TM_Learn" button to learn a power
-        var replacedLearnButton = instr.ReplaceMethod(targetTextButton, textButtonReplacement, baseMethod, ExtraInstructions, 1, "TM_Learn", "TM_MCU_PointsToLearn");
+        var replacedLearnButton = instr.ReplaceMethod(targetTextButton, textButtonReplacement, baseMethod, ExtraInstructions, null, 1, "TM_Learn", "TM_MCU_PointsToLearn");
         // Replace the image button to level-up a power
-        return replacedLearnButton.ReplaceMethod(targetImageButton, imageButtonReplacement, baseMethod, ExtraInstructions, 1);
+        return replacedLearnButton.ReplaceMethod(targetImageButton, imageButtonReplacement, baseMethod, ExtraInstructions, null, 1);
     }
 
     #endregion
@@ -1370,7 +1370,7 @@ public class ARimWorldOfMagic
         ];
 
         // The "Apply" text isn't translated in the mod...
-        return instr.ReplaceMethod(target, replacement, baseMethod, ExtraInstructions, 1, "Apply");
+        return instr.ReplaceMethod(target, replacement, baseMethod, ExtraInstructions, null, 1, "Apply");
     }
 
     #endregion


### PR DESCRIPTION
- The opcode of replaced method is based on the new method, rather than the one it replaces
- Added `extraInstructionsAfter` argument to insert instructions after the targeted code instruction
- The `extraInstructions` argument was renamed to `extraInstructionsBefore`
- Made the method replacement (and the argument for it) optional
  - The method can now be used to insert extra instructions before/after the targeted method without replacing it
- An exception will be thrown if the `IEnumerable<CodeInstruction>` is null
  - It feels like the best course of action, as not doing anything will cause an exception later on and returning anything (or nothing) could have an unexpected consequences
- An error will be displayed if the method was provided a null target method
- An error will be displayed if the method was not provided a replacement method or a function to insert extra instructions
- Updated the compat for "A RimWorld of Magic" to support the new method signature