### PR TITLE
Remove unnecessary RNG patch for Vanilla Ideology Expanded - Memes and Structures

### DIFF
--- a/Source/Mods/VanillaIdeologyMemes.cs
+++ b/Source/Mods/VanillaIdeologyMemes.cs
@@ -26,7 +26,6 @@ namespace Multiplayer.Compat
                     //"VanillaMemesExpanded.VanillaMemesExpanded_GameConditionManager_RegisterCondition_Patch:SendRandomMood",
                     //"VanillaMemesExpanded.VanillaMemesExpanded_GameCondition_Aurora_Init_Patch:SendRandomMood",
                     //"VanillaMemesExpanded.RitualOutcomeEffectWorker_DivineStars:Apply",
-                    "VanillaMemesExpanded.RitualOutcomeEffectWorker_SlaveEmancipation:Apply",
                     "VanillaMemesExpanded.RitualOutcomeEffectWorker_ViolentConversion:Apply",
                 };
 


### PR DESCRIPTION
Looks like one of the places that system RNG was used in was replaced with Verse RNG, making this single patch obsolete.