### PR TITLE
Fix wrong target for Harmony prefix for Vanilla Recycling Expanded

### DIFF
--- a/Source/Mods/VanillaRecyclingExpanded.cs
+++ b/Source/Mods/VanillaRecyclingExpanded.cs
@@ -14,7 +14,7 @@ public class VanillaRecyclingExpanded
         MpCompatPatchLoader.LoadPatch(this);
 
         var type = AccessTools.TypeByName("VanillaRecyclingExpanded.CompBiopackDissolution");
-        // Dev: Single dissolution event (0), dissolution events until destroyed (1), +25% dissolution progress
+        // Dev: Single dissolution event (0), dissolution events until destroyed (1), +25% dissolution progress (2)
         MpCompat.RegisterLambdaMethod(type, nameof(ThingComp.CompGetGizmosExtra), 0, 1, 2).SetDebugOnly();
         // Dev: Set next dissolve time
         MP.RegisterSyncDelegateLambda(type, nameof(ThingComp.CompGetGizmosExtra), 4).SetDebugOnly();
@@ -30,6 +30,6 @@ public class VanillaRecyclingExpanded
     }
 
     // Stop methods from running (most likely after syncing) when it would cause errors or other issues.
-    [MpCompatPrefix("VanillaRecyclingExpanded.CompBiopackDissolution", "TriggerDissolutionEvent")]
+    [MpCompatPrefix("VanillaRecyclingExpanded.CompSuperSimpleProcessor", "DoAtomize")]
     private static bool PreDoAtomize(CompThingContainer __instance) => __instance.ContainedThing is { stackCount: > 0 };
 }


### PR DESCRIPTION
It looks like I've targeted a wrong method with a Harmony prefix. This caused 2 issues:

The first is that the prefix caused reclaimed biopacks from properly dissolving, throwing an exception and potentially causing quite a bit of lag.

The second is that the method that was meant to be patched could be called when it's not supposed to, meaning that the item processor would attempt to reduce the stack size by 1 while it's at 0. Only possible in dev mode, but still possible.

This should change the method to patch the correct method. On top of that, I've updated 1 of the comments in there as well.