### PR TITLE
Support several continued/updated mods

### DIFF
--- a/Source/Mods/AlmostThere.cs
+++ b/Source/Mods/AlmostThere.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using HarmonyLib;
-using Multiplayer.API;
+﻿using RimWorld.Planet;
 using Verse;
 
 namespace Multiplayer.Compat
@@ -9,62 +7,13 @@ namespace Multiplayer.Compat
     /// <see href="https://github.com/rheirman/AlmostThere"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2372543327"/>
     [MpCompatFor("roolo.AlmostThere")]
+    [MpCompatFor("Chad.Almostthere1.5")]
     public class AlmostThere
     {
-        // Base class
-        private static FastInvokeHandler almostThereInstance;
-        private static AccessTools.FieldRef<object, object> extendedDataStorageField;
-
-        // ExtendedDataStorage class
-        private static AccessTools.FieldRef<object, IDictionary> storeField;
-
         public AlmostThere(ModContentPack mod)
         {
-            var type = AccessTools.TypeByName("AlmostThere.Harmony.Caravan_GetGizmos");
-
-            MpCompat.RegisterLambdaDelegate(type, "CreateIgnoreRestCommand", 1);
-            MpCompat.RegisterLambdaDelegate(type, "CreateAlmostThereCommand", 1);
-            MpCompat.RegisterLambdaDelegate(type, "CreateForceRestCommand", 1);
-
-            type = AccessTools.TypeByName("AlmostThere.Base");
-            almostThereInstance = MethodInvoker.GetHandler(AccessTools.PropertyGetter(type, "Instance"));
-            extendedDataStorageField = AccessTools.FieldRefAccess<object>(type, "_extendedDataStorage");
-
-            type = AccessTools.TypeByName("AlmostThere.Storage.ExtendedCaravanData");
-            MP.RegisterSyncWorker<object>(SyncExtendedCaravanData, type);
-
-            storeField = AccessTools.FieldRefAccess<IDictionary>("AlmostThere.Storage.ExtendedDataStorage:_store");
-        }
-
-        private static void SyncExtendedCaravanData(SyncWorker sync, ref object caravanData)
-        {
-            var instance = almostThereInstance(null);
-            var dataStorage = extendedDataStorageField(instance);
-            var dictionary = storeField(dataStorage);
-
-            if (sync.isWriting)
-            {
-                var found = false;
-
-                foreach (DictionaryEntry entry in dictionary)
-                {
-                    if (entry.Value == caravanData)
-                    {
-                        sync.Write((int)entry.Key);
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found)
-                    sync.Write(int.MinValue);
-            }
-            else
-            {
-                var id = sync.Read<int>();
-                if (id != int.MinValue)
-                    caravanData = dictionary[id];
-            }
+            // Toggle: almost there (1), never rest (3), force rest (5)
+            MpCompat.RegisterLambdaMethod("AlmostThere.AlmostThereWorldObjectComp", nameof(WorldObjectComp.GetGizmos), 1, 3, 5);
         }
     }
 }

--- a/Source/Mods/CleaningArea.cs
+++ b/Source/Mods/CleaningArea.cs
@@ -8,13 +8,15 @@ namespace Multiplayer.Compat
     /// <summary>Cleaning Area by Hatti</summary>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=870089952"/>
     [MpCompatFor("hatti.cleaningarea")]
+    [MpCompatFor("s1.cleaningareatemp")]
     public class CleaningArea
     {
         static Type CleaningAreaMapComponentType;
         
         public CleaningArea(ModContentPack mod)
         {
-            Type type = CleaningAreaMapComponentType = AccessTools.TypeByName("CleaningArea.CleaningArea_MapComponent");
+            Type type = CleaningAreaMapComponentType = AccessTools.TypeByName("CleaningArea.CleaningArea_MapComponent") ??
+                                                       AccessTools.TypeByName("CleaningAreaTemp.CleaningArea_MapComponent");
 
             MP.RegisterSyncMethod(AccessTools.PropertySetter(type, "cleaningArea"));
             MP.RegisterSyncWorker<MapComponent>(SyncWorkerForCleaningArea, type);

--- a/Source/Mods/CutPlantsBeforeBuilding.cs
+++ b/Source/Mods/CutPlantsBeforeBuilding.cs
@@ -7,6 +7,7 @@ namespace Multiplayer.Compat
     /// <summary>Cut plants before building by tammybee</summary>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1539025677"/>
     [MpCompatFor("tammybee.cutplantsbeforebuilding")]
+    [MpCompatFor("Mlie.CutPlantsBeforeBuilding")]
     class CutPlantsBeforeBuilding
     {
         private static ISyncField syncAutoCutPlants;
@@ -16,9 +17,9 @@ namespace Multiplayer.Compat
         private static void LatePatch()
         {
             syncAutoCutPlants = MP.RegisterSyncField(
-                AccessTools.Field(AccessTools.TypeByName("CutPlantsBeforeBuilding.Main"), "autoDesignatePlantsCutMode"));
-            MpCompat.harmony.Patch(AccessTools.Method("CutPlantsBeforeBuilding.PlaySettings_DoPlaySettingsGlobalControls_Patch:Prefix"),
-                prefix: new HarmonyMethod(typeof(CutPlantsBeforeBuilding), nameof(WatchAutoCutPlantsPrefix)));
+                AccessTools.Field(AccessTools.TypeByName("CutPlantsBeforeBuilding.Main"), "AutoDesignatePlantsCutMode"));
+            MpCompat.harmony.Patch(AccessTools.Method("CutPlantsBeforeBuilding.HarmonyPatches.PlaySettings_DoPlaySettingsGlobalControls:Prefix"),
+                prefix: new HarmonyMethod(WatchAutoCutPlantsPrefix));
         }
 
         // No need to begin and end watching, as this prefix is already called in a place where it's done by the MP mod

--- a/Source/Mods/DeepStorageGUI.cs
+++ b/Source/Mods/DeepStorageGUI.cs
@@ -8,6 +8,7 @@ namespace Multiplayer.Compat
     /// <see href="https://github.com/Dakraid/RW_DSGUI/"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2169841018"/>
     [MpCompatFor("netrve.dsgui")]
+    [MpCompatFor("Mlie.NetrvesDeepStorageGUI")]
     class DeepStorageGUI
     {
         public DeepStorageGUI(ModContentPack mod)

--- a/Source/Mods/FertileFields.cs
+++ b/Source/Mods/FertileFields.cs
@@ -8,34 +8,28 @@ namespace Multiplayer.Compat
     /// <summary>Fertile Fields by Jamaican Castle</summary>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2012735237"/>
     [MpCompatFor("jamaicancastle.RF.fertilefields")]
+    [MpCompatFor("greysuki.RF.fertilefields")]
     class FertileFieldsCompat
     {
-        readonly Type GrowZoneManagerType;
-
         public FertileFieldsCompat(ModContentPack mod)
         {
+            LongEventHandler.ExecuteWhenFinished(LatePatch);
+
             {
                 // RNG
                 PatchingUtilities.PatchSystemRand("RFF_Code.Building_CompostBin:PlaceProduct");
             }
 
-            Type type = GrowZoneManagerType = AccessTools.TypeByName("RFF_Code.GrowZoneManager");
+            Type type = AccessTools.TypeByName("RFF_Code.GrowZoneManager");
 
             MP.RegisterSyncMethod(type, "ToggleReturnToSoil");
             MP.RegisterSyncMethod(type, "ToggleDesignateReplacements");
-
-            MP.RegisterSyncWorker<MapComponent>(SyncWorkerForGrowZoneManager, type);
         }
 
-        void SyncWorkerForGrowZoneManager(SyncWorker sync, ref MapComponent obj)
+        private static void LatePatch()
         {
-            if (sync.isWriting) {
-                sync.Write(obj.map);
-            } else {
-                var map = sync.Read<Map>();
-
-                obj = map.GetComponent(GrowZoneManagerType);
-            }
+            // Dev: set progress to 1
+            MpCompat.RegisterLambdaMethod("RFF_Code.Building_CompostBarrel", nameof(Building.GetGizmos), 0).SetDebugOnly();
         }
     }
 }

--- a/Source/Mods/MoreArchotechGarbage.cs
+++ b/Source/Mods/MoreArchotechGarbage.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using HarmonyLib;
+﻿using HarmonyLib;
+using Multiplayer.API;
 using Verse;
 
 namespace Multiplayer.Compat
@@ -7,6 +7,8 @@ namespace Multiplayer.Compat
     /// <summary>More Archotech Garbage by MrKociak</summary>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2391102796"/>
     [MpCompatFor("MrKociak.MoreArchotechStuffandThingsReupload")]
+    [MpCompatFor("Taranchuk.MoreArchotechGarbageContinued")]
+    [MpCompatFor("zal.morearchotechgarbage")]
     internal class MoreArchotechGarbage
     {
         public MoreArchotechGarbage(ModContentPack mod)
@@ -15,12 +17,16 @@ namespace Multiplayer.Compat
             {
                 var rngTypes = new[]
                 {
-                    "RimWorld.CompSpawnerH",
-                    "RimWorld.CompSpawnerResearch",
-                    "RimWorld.CompSpawnerResearchMK2",
-                    "RimWorld.JoinOrRaidTameOrManhunter",
-                    "RimWorld.MechhSummon",
-                    "RimWorld.MechhSummonNoRoyalty",
+                    "MoreArchotechGarbage.CompSpawnerH",
+                    "MoreArchotechGarbage.CompSpawnerResearch",
+                    "MoreArchotechGarbage.CompSpawnerResearchMK2",
+                    "MoreArchotechGarbage.JoinOrRaidTameOrManhunter",
+                    "MoreArchotechGarbage.MechhSummon",
+                    "MoreArchotechGarbage.MechhSummonNoRoyalty",
+                    // Unused?
+                    "MoreArchotechGarbage.CompSpawnerExtraRaidsOne",
+                    "MoreArchotechGarbage.CompSpawnerExtraRaidsTwo",
+                    "MoreArchotechGarbage.CompSpawnerExtraRaidsThree",
                 };
 
                 foreach (var type in rngTypes) PatchingUtilities.PatchSystemRand($"{type}:RandomNumber");
@@ -29,22 +35,31 @@ namespace Multiplayer.Compat
             // Gizmo Fix
             {
                 // Mech cluster (0), raid (2), ship part (4)
-                var type = AccessTools.TypeByName("RimWorld.MechhSummon");
-                MpCompat.RegisterLambdaDelegate(type, "GetGizmos", Array.Empty<string>(), 0, 2);
-                MpCompat.RegisterLambdaMethod(type, "GetGizmos", 4);
+                var type = AccessTools.TypeByName("MoreArchotechGarbage.MechhSummon");
+                MpCompat.RegisterLambdaDelegate(type, nameof(Building.GetGizmos), 0, 2);
+                MpCompat.RegisterLambdaMethod(type, nameof(Building.GetGizmos), 4);
 
                 // Raid (0), ship part (2)
-                type = AccessTools.TypeByName("RimWorld.MechhSummonNoRoyalty");
-                MpCompat.RegisterLambdaDelegate(type, "GetGizmos", Array.Empty<string>(), 0);
-                MpCompat.RegisterLambdaMethod(type, "GetGizmos", 2);
+                type = AccessTools.TypeByName("MoreArchotechGarbage.MechhSummonNoRoyalty");
+                MpCompat.RegisterLambdaDelegate(type, nameof(Building.GetGizmos), 0);
+                MpCompat.RegisterLambdaMethod(type, nameof(Building.GetGizmos), 2);
 
                 // Summon meteorite
-                MpCompat.RegisterLambdaDelegate("RimWorld.PodSummoner", "GetGizmos", Array.Empty<string>(), 0);
+                MpCompat.RegisterLambdaDelegate("MoreArchotechGarbage.PodSummoner", nameof(Building.GetGizmos), 0);
 
                 // Dev mode gizmos
-                MpCompat.RegisterLambdaMethod("RimWorld.CompSpawnerH", "CompGetGizmosExtra", 0).SetDebugOnly();
-                MpCompat.RegisterLambdaMethod("RimWorld.CompSpawnerResearch", "CompGetGizmosExtra", 0).SetDebugOnly();
-                MpCompat.RegisterLambdaMethod("RimWorld.CompSpawnerResearchMK2", "CompGetGizmosExtra", 0).SetDebugOnly();
+                MpCompat.RegisterLambdaMethod("MoreArchotechGarbage.CompSpawnerH", nameof(ThingComp.CompGetGizmosExtra), 0).SetDebugOnly();
+                MpCompat.RegisterLambdaMethod("MoreArchotechGarbage.CompSpawnerResearch", nameof(ThingComp.CompGetGizmosExtra), 0).SetDebugOnly();
+                MpCompat.RegisterLambdaMethod("MoreArchotechGarbage.CompSpawnerResearchMK2", nameof(ThingComp.CompGetGizmosExtra), 0).SetDebugOnly();
+                MpCompat.RegisterLambdaMethod("MoreArchotechGarbage.CompSpawnerExtraRaidsOne", nameof(ThingComp.CompGetGizmosExtra), 0).SetDebugOnly();
+                MpCompat.RegisterLambdaMethod("MoreArchotechGarbage.CompSpawnerExtraRaidsTwo", nameof(ThingComp.CompGetGizmosExtra), 0).SetDebugOnly();
+                MpCompat.RegisterLambdaMethod("MoreArchotechGarbage.CompSpawnerExtraRaidsThree", nameof(ThingComp.CompGetGizmosExtra), 0).SetDebugOnly();
+
+                // Summon a person to join your colony (0), tame a random animal nearby (3)
+                MpCompat.RegisterLambdaMethod("MoreArchotechGarbage.JoinOrRaidTameOrManhunter", nameof(Building.GetGizmos), 0, 3);
+
+                // Start carging
+                MP.RegisterSyncMethod(AccessTools.DeclaredMethod("MoreArchotechGarbage.Building_MAG_HibernationStarter:MAG_StartupHibernatingParts"));
             }
         }
     }

--- a/Source/Mods/PerspectiveBuildings.cs
+++ b/Source/Mods/PerspectiveBuildings.cs
@@ -8,6 +8,7 @@ namespace Multiplayer.Compat
     /// <see href="https://github.com/Owlchemist/perspective-buildings"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2594383552"/>
     [MpCompatFor("Owlchemist.PerspectiveBuildings")]
+    [MpCompatFor("Mlie.PerspectiveBuildings")]
     internal class PerspectiveBuildings
     {
         public PerspectiveBuildings(ModContentPack mod)

--- a/Source/Mods/PrisonCommons.cs
+++ b/Source/Mods/PrisonCommons.cs
@@ -7,6 +7,7 @@ namespace Multiplayer.Compat
     /// <see href="https://steamcommunity.com/workshop/filedetails/?id=2630896782"/>
     [MpCompatFor("me.lubar.PrisonCommons")]
     [MpCompatFor("me.lubar.PrisonCommons.temp")]
+    [MpCompatFor("Mlie.PrisonCommons")]
     internal class PrisonCommons
     {
         public PrisonCommons(ModContentPack mod) 

--- a/Source/Mods/RimsentialSpaceports.cs
+++ b/Source/Mods/RimsentialSpaceports.cs
@@ -9,6 +9,7 @@ namespace Multiplayer.Compat
     /// <see href="https://github.com/SomewhereOutInSpace/Rimworld-Spaceports"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2663999215"/>
     [MpCompatFor("SomewhereOutInSpace.Spaceports")]
+    [MpCompatFor("zal.spaceports")]
     internal class RimsentialSpaceports
     {
         public RimsentialSpaceports(ModContentPack mod)

--- a/Source/Mods/WhatTheHack.cs
+++ b/Source/Mods/WhatTheHack.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Reflection;
 using HarmonyLib;
 using Multiplayer.API;
 using RimWorld;
@@ -13,6 +12,7 @@ namespace Multiplayer.Compat
     /// <see href="https://github.com/rheirman/WhatTheHack/"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1505914869"/>
     [MpCompatFor("roolo.whatthehack")]
+    [MpCompatFor("zal.whatthehack")]
     class WhatTheHack
     {
         private static Dictionary<int, Thing> thingsById;
@@ -47,14 +47,16 @@ namespace Multiplayer.Compat
             {
                 var methods = new[]
                 {
-                    AccessTools.Method(AccessTools.TypeByName("WhatTheHack.Harmony.IncidentWorker_Raid_TryExecuteWorker"), "SpawnHackedMechanoids"),
-                    AccessTools.Method(AccessTools.TypeByName("WhatTheHack.Harmony.Pawn_JobTracker_DetermineNextJob"), "HackedPoorlyEvent"),
-                    AccessTools.Method(AccessTools.TypeByName("WhatTheHack.Harmony.Thing_ButcherProducts+<GenerateExtraButcherProducts>d__1"), "MoveNext"),
-                    AccessTools.Method(AccessTools.TypeByName("WhatTheHack.Needs.Need_Maintenance"), "MaybeUnhackMechanoid"),
-                    AccessTools.Method(AccessTools.TypeByName("WhatTheHack.Recipes.Recipe_Hacking"), "CheckHackingFail"),
+                    "WhatTheHack.Harmony.IncidentWorker_Raid_TryExecuteWorker:Prefix",
+                    "WhatTheHack.Harmony.Pawn_JobTracker_DetermineNextJob:HackedPoorlyEvent",
+                    "WhatTheHack.Needs.Need_Maintenance:MaybeUnhackMechanoid",
+                    "WhatTheHack.Recipes.Recipe_Hacking:CheckHackingFail",
                 };
 
                 PatchingUtilities.PatchSystemRand(methods, false);
+
+                var type = AccessTools.TypeByName("WhatTheHack.Harmony.Thing_ButcherProducts");
+                PatchingUtilities.PatchSystemRand(MpMethodUtil.GetMethod(type, "GenerateExtraButcherProducts", MethodType.Enumerator, [typeof(IEnumerable<Thing>), typeof(Pawn), typeof(float)]));
             }
 
             // Gizmos


### PR DESCRIPTION
- Every mod that I could find that has a "continued" or any other sort of updated version
  - This obviously excludes the few that share the mod ID with the original (Hemogen Extractor, Perspective: Ores)
  - I've included Taranchuk's More Archotech Garbage despite it being discontinued just in case it ever gets picked up in the future (and hopefully forked off of the most recent version)
- Almost There compat had most of the patch removed, as the continued version simplified the code by using a `WorldObjectComp`
- Cleaning Area compat now targets additional type, as the namespace is slightly different
- Cut Plants Before Building compat was changed to target new class/field names and type namespace
- Fertile Fields doesn't sync MapComp anymore, as it's not needed
- Fertile Fields syncs an additional dev mode gizmo
- More Archotech Garbage is now targeting `MoreArchotechGarbage` rather than `RimWorld`, as the latest fork changed it
- More Archotech Garbage now replaces more RNG and syncs more gizmos, as latest fork added those
- PokéWorld had its syncing changed (fixing errors) to use `MpMethodUtil.GetLambda` rather than referencing lambdas directly
- PokéWorld had other minor fixes, like changing lambda ordinals and removing syncing of method that was never synced
- What The Hack now uses `MpMethodUtil.GetMethod` to get an enumerator's GetNext method
- A bunch of other minor changes, like small changes to comments or using features of more recent C# versions