### PR TITLE
Add new RegisterLambdaMethod/RegisterLambdaDelegate variants

### DIFF
--- a/Source/MpCompat.cs
+++ b/Source/MpCompat.cs
@@ -27,51 +27,82 @@ namespace Multiplayer.Compat
         }
 
         static IEnumerable<ISyncMethod> RegisterLambdaMethod_Impl(Type parentType, string parentMethod, params int[] lambdaOrdinals)
+        static IEnumerable<ISyncMethod> RegisterLambdaMethod_Impl(Type parentType, string parentMethod, MethodType methodType, params int[] lambdaOrdinals)
         {
             foreach (int ord in lambdaOrdinals)
             {
-                var method = MpMethodUtil.GetLambda(parentType, parentMethod, MethodType.Normal, null, ord);
+                var method = MpMethodUtil.GetLambda(parentType, parentMethod, methodType, null, ord);
                 yield return MP.RegisterSyncMethod(method);
             }
         }
 
+        public static ISyncMethod[] RegisterLambdaMethod(Type parentType, string parentMethod, MethodType methodType, params int[] lambdaOrdinals)
+        {
+            return RegisterLambdaMethod_Impl(parentType, parentMethod, methodType, lambdaOrdinals).ToArray();
+        }
+
         public static ISyncMethod[] RegisterLambdaMethod(Type parentType, string parentMethod, params int[] lambdaOrdinals)
         {
-            return RegisterLambdaMethod_Impl(parentType, parentMethod, lambdaOrdinals).ToArray();
+            return RegisterLambdaMethod_Impl(parentType, parentMethod, MethodType.Normal, lambdaOrdinals).ToArray();
+        }
+
+        public static ISyncMethod[] RegisterLambdaMethod(string parentType, string parentMethod, MethodType methodType = MethodType.Normal, params int[] lambdaOrdinals)
+        {
+            return RegisterLambdaMethod_Impl(AccessTools.TypeByName(parentType), parentMethod, methodType, lambdaOrdinals).ToArray();
         }
 
         public static ISyncMethod[] RegisterLambdaMethod(string parentType, string parentMethod, params int[] lambdaOrdinals)
         {
-            return RegisterLambdaMethod_Impl(AccessTools.TypeByName(parentType), parentMethod, lambdaOrdinals).ToArray();
+            return RegisterLambdaMethod_Impl(AccessTools.TypeByName(parentType), parentMethod, MethodType.Normal, lambdaOrdinals).ToArray();
         }
 
-        static IEnumerable<ISyncDelegate> RegisterLambdaDelegate_Impl(Type parentType, string parentMethod, string[] fields, params int[] lambdaOrdinals)
+        static IEnumerable<ISyncDelegate> RegisterLambdaDelegate_Impl(Type parentType, string parentMethod, MethodType methodType, string[] fields, params int[] lambdaOrdinals)
         {
             foreach (int ord in lambdaOrdinals)
             {
-                var method = MpMethodUtil.GetLambda(parentType, parentMethod, MethodType.Normal, null, ord);
+                var method = MpMethodUtil.GetLambda(parentType, parentMethod, methodType, null, ord);
                 yield return MP.RegisterSyncDelegate(parentType, method.DeclaringType.Name, method.Name, fields);
             }
         }
 
         public static ISyncDelegate[] RegisterLambdaDelegate(Type parentType, string parentMethod, params int[] lambdaOrdinals)
         {
-            return RegisterLambdaDelegate_Impl(parentType, parentMethod, null, lambdaOrdinals).ToArray();
+            return RegisterLambdaDelegate_Impl(parentType, parentMethod, MethodType.Normal, null, lambdaOrdinals).ToArray();
         }
 
         public static ISyncDelegate[] RegisterLambdaDelegate(Type parentType, string parentMethod, string[] fields, params int[] lambdaOrdinals)
         {
-            return RegisterLambdaDelegate_Impl(parentType, parentMethod, fields, lambdaOrdinals).ToArray();
+            return RegisterLambdaDelegate_Impl(parentType, parentMethod, MethodType.Normal, fields, lambdaOrdinals).ToArray();
+        }
+
+        public static ISyncDelegate[] RegisterLambdaDelegate(Type parentType, string parentMethod, MethodType methodType, params int[] lambdaOrdinals)
+        {
+            return RegisterLambdaDelegate_Impl(parentType, parentMethod, methodType, null, lambdaOrdinals).ToArray();
+        }
+
+        public static ISyncDelegate[] RegisterLambdaDelegate(Type parentType, string parentMethod, MethodType methodType, string[] fields, params int[] lambdaOrdinals)
+        {
+            return RegisterLambdaDelegate_Impl(parentType, parentMethod, methodType, fields, lambdaOrdinals).ToArray();
         }
 
         public static ISyncDelegate[] RegisterLambdaDelegate(string parentType, string parentMethod, params int[] lambdaOrdinals)
         {
-            return RegisterLambdaDelegate_Impl(AccessTools.TypeByName(parentType), parentMethod, null, lambdaOrdinals).ToArray();
+            return RegisterLambdaDelegate_Impl(AccessTools.TypeByName(parentType), parentMethod, MethodType.Normal, null, lambdaOrdinals).ToArray();
         }
 
         public static ISyncDelegate[] RegisterLambdaDelegate(string parentType, string parentMethod, string[] fields, params int[] lambdaOrdinals)
         {
-            return RegisterLambdaDelegate_Impl(AccessTools.TypeByName(parentType), parentMethod, fields, lambdaOrdinals).ToArray();
+            return RegisterLambdaDelegate_Impl(AccessTools.TypeByName(parentType), parentMethod, MethodType.Normal, fields, lambdaOrdinals).ToArray();
+        }
+
+        public static ISyncDelegate[] RegisterLambdaDelegate(string parentType, string parentMethod, MethodType methodType, params int[] lambdaOrdinals)
+        {
+            return RegisterLambdaDelegate_Impl(AccessTools.TypeByName(parentType), parentMethod, methodType, null, lambdaOrdinals).ToArray();
+        }
+
+        public static ISyncDelegate[] RegisterLambdaDelegate(string parentType, string parentMethod, MethodType methodType, string[] fields, params int[] lambdaOrdinals)
+        {
+            return RegisterLambdaDelegate_Impl(AccessTools.TypeByName(parentType), parentMethod, methodType, fields, lambdaOrdinals).ToArray();
         }
     }
 }

--- a/Source/MpCompat.cs
+++ b/Source/MpCompat.cs
@@ -26,7 +26,6 @@ namespace Multiplayer.Compat
             harmony.PatchAll();
         }
 
-        static IEnumerable<ISyncMethod> RegisterLambdaMethod_Impl(Type parentType, string parentMethod, params int[] lambdaOrdinals)
         static IEnumerable<ISyncMethod> RegisterLambdaMethod_Impl(Type parentType, string parentMethod, MethodType methodType, params int[] lambdaOrdinals)
         {
             foreach (int ord in lambdaOrdinals)


### PR DESCRIPTION
Added `MP.RegisterLambdaMethod` and `MP.RegisterLambdaDelegate` method variants with new arguments (`MethodType`) to allow targeting other method types, like getters and setters.