### PR TITLE
Remove obsolete RNG patching

### DIFF
--- a/Source/Mods/VanillaFactionsTribal.cs
+++ b/Source/Mods/VanillaFactionsTribal.cs
@@ -19,14 +19,6 @@ namespace Multiplayer.Compat
             // Needs to be done late or will cause issues with resource loading from non-main thread.
             LongEventHandler.ExecuteWhenFinished(() => MpCompatPatchLoader.LoadPatch(this));
 
-            #region RNG
-
-            {
-                PatchingUtilities.PatchSystemRand("VFETribals.RitualOutcomeEffectWorker_TribalGathering:Apply", false);
-            }
-
-            #endregion
-
             #region Gizmos
 
             {


### PR DESCRIPTION
This now uses Rimworld's Rand and produces a warning that there was no patching needed. So might as well remove it.