### PR TITLE
fix(VGE): replace BlackBox manual prefix+SyncMethod with RegisterLambdaDelegate

### DIFF
--- a/Source/Mods/VanillaGravshipExpanded.cs
+++ b/Source/Mods/VanillaGravshipExpanded.cs
@@ -126,14 +126,10 @@ namespace Multiplayer.Compat
             #region Gizmo actions
 
             {
-                // Building_GravshipBlackBox - convert gravdata to research
-                // Lambda captures a local (currentProject), creating a display class MP can't serialize.
-                // Sync via prefix + SyncMethod instead.
-                var blackBoxType = AccessTools.TypeByName("VanillaGravshipExpanded.Building_GravshipBlackBox");
-                var blackBoxLambda = MpMethodUtil.GetLambda(blackBoxType, "GetGizmos", lambdaOrdinal: 0);
-                MpCompat.harmony.Patch(blackBoxLambda,
-                    prefix: new HarmonyMethod(typeof(VanillaGravshipExpanded), nameof(PreBlackBoxConvert)));
-                MP.RegisterSyncMethod(typeof(VanillaGravshipExpanded), nameof(SyncedBlackBoxConvert));
+                // Building_GravshipBlackBox - convert gravdata to research (lambda 0)
+                // Lambda captures this + currentProject local, creating a display class.
+                // RegisterLambdaDelegate decomposes the display class fields for serialization.
+                MpCompat.RegisterLambdaDelegate("VanillaGravshipExpanded.Building_GravshipBlackBox", "GetGizmos", 0);
 
                 // Building_SealantPopper - toggle autoRebuild (lambda 1, after isActive getter at 0)
                 MpCompat.RegisterLambdaMethod("VanillaGravshipExpanded.Building_SealantPopper", "GetGizmos", 1);
@@ -439,47 +435,6 @@ namespace Multiplayer.Compat
         {
             if (!MP.IsExecutingSyncCommand)
                 CameraJumper.TryHideWorld();
-        }
-
-        /// <summary>
-        /// Intercept the black box convert gravdata lambda and sync it.
-        /// The lambda captures a local variable (currentProject), so we
-        /// replicate the logic in SyncedBlackBoxConvert instead.
-        /// </summary>
-        private static bool PreBlackBoxConvert(object __instance)
-        {
-            if (!MP.IsInMultiplayer)
-                return true;
-
-            // __instance is the display class; get the building from its fields
-            var buildingField = __instance.GetType().GetField("<>4__this");
-            if (buildingField?.GetValue(__instance) is Thing building)
-                SyncedBlackBoxConvert(building);
-
-            return false;
-        }
-
-
-        private static void SyncedBlackBoxConvert(Thing blackBox)
-        {
-            var currentProject = Find.ResearchManager.currentProj;
-            if (currentProject == null || currentProject.IsFinished)
-                return;
-
-            var storedField = AccessTools.Field(blackBox.GetType(), "storedGravdata");
-            if (storedField == null)
-                return;
-
-            var stored = (float)storedField.GetValue(blackBox);
-            if (stored <= 0)
-                return;
-
-            float progressNeeded = currentProject.Cost - Find.ResearchManager.GetProgress(currentProject);
-            float gravdataToConvert = Math.Min(stored, progressNeeded);
-            Find.ResearchManager.AddProgress(currentProject, gravdataToConvert);
-            storedField.SetValue(blackBox, stored - gravdataToConvert);
-            Messages.Message("VGE_ConvertedGravdataToResearch".Translate(gravdataToConvert, currentProject.LabelCap),
-                MessageTypeDefOf.TaskCompletion);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Replaces manual prefix+SyncMethod pattern for BlackBox gravdata conversion with `RegisterLambdaDelegate`
- Removes `PreBlackBoxConvert` and `SyncedBlackBoxConvert` methods (-49 lines)
- The original pattern copy-pasted the mod's convert logic, meaning any VGE change to the conversion would silently diverge

## Root cause
The lambda in `Building_GravshipBlackBox.GetGizmos` captures `this` (Thing) and a local variable `currentProject` (ResearchProjectDef). The compiler generates a display class to hold these captures. `RegisterLambdaDelegate` handles this by decomposing the display class into its individual captured fields for serialization — both are natively serializable (Thing, Def).

The original comment claimed "MP can't serialize" the display class. The display class *type* indeed has no sync writer, but its *fields* are serializable — exactly the case `RegisterLambdaDelegate` is designed for.

## Approach
One-line replacement: `MpCompat.RegisterLambdaDelegate("VanillaGravshipExpanded.Building_GravshipBlackBox", "GetGizmos", 0)`.

Alternatives considered:
- `RegisterLambdaMethod` — fails because it registers the lambda as a SyncMethod with the display class as target. MP has no writer for the display class type. Confirmed in-game: `SerializationException: No writer for type <>c__DisplayClass3_0`.
- Keep the manual pattern — works but is fragile. Any VGE change to the convert logic requires a matching compat patch update.

## Test plan
- [x] Builds cleanly (0 warnings, 0 errors)
- [x] Manual in-game test: selected BlackBox with stored gravdata, active research project, clicked "Convert Gravdata" gizmo in MP — research progress increased, gravdata decreased, completion message appeared, no desync

🤖 Generated with [Claude Code](https://claude.com/claude-code)