### PR TITLE
fix(VGE): correct Building_Gravlift lambda ordinal and API

### DIFF
--- a/Source/Mods/VanillaGravshipExpanded.cs
+++ b/Source/Mods/VanillaGravshipExpanded.cs
@@ -209,9 +209,11 @@ namespace Multiplayer.Compat
             #region Building_Gravlift (launch to orbit)
 
             {
-                // Gizmo lambda sets IsGravliftLaunch then calls ShowRitualBeginWindow.
-                // MP intercepts ShowRitualBeginWindow to create a RitualSession.
-                MpCompat.RegisterLambdaMethod("VanillaGravshipExpanded.Building_Gravlift", "GetGizmos", 0);
+                // Ordinal 2: gizmo action — sets IsGravliftLaunch, calls ShowLaunchRitual
+                // Captures locals (isInOrbit, comp) via display class, so must use Delegate not Method.
+                // (0: LINQ Select projection, 1: LINQ FirstOrDefault predicate — both non-capturing in <>c)
+                // Verified: https://github.com/Vanilla-Expanded/VanillaGravshipExpanded/blob/main/Source/Things/Building_Gravlift.cs
+                MpCompat.RegisterLambdaDelegate("VanillaGravshipExpanded.Building_Gravlift", "GetGizmos", 2);
             }
 
             #endregion


### PR DESCRIPTION
## Summary
- Fixes `Building_Gravlift.GetGizmos` lambda sync registration
- Ordinal 0→2: ordinal 0 targeted a LINQ `.Select()` projection, not the gizmo action
- `RegisterLambdaMethod`→`RegisterLambdaDelegate`: the gizmo action lambda captures locals (`isInOrbit`, `comp`) via a display class — `RegisterSyncMethod` fails with "No writer for type", `RegisterSyncDelegate` decomposes the display class fields correctly

## Test plan
- [x] Load MP game with VGE, select a gravlift — no serialization error
- [x] Click "Launch to Orbit" — ritual dialog opens on both host and client

🤖 Generated with [Claude Code](https://claude.com/claude-code)