### PR TITLE
fix(VGE): remove forced orbitalObjectsMultiplier override

### DIFF
--- a/Source/Mods/VanillaGravshipExpanded.cs
+++ b/Source/Mods/VanillaGravshipExpanded.cs
@@ -45,10 +45,6 @@ namespace Multiplayer.Compat
         private static AccessTools.FieldRef<object, object> vacBarrierDialogBarriersField;
         private static MethodInfo notifyBarrierColorChangedMethod;
 
-        // Mod settings - orbitalObjectsMultiplier must be consistent in MP
-        private static AccessTools.FieldRef<float> orbitalObjectsMultiplierField;
-        private static float savedMultiplier;
-
         // VGE launch flow - sync tile selection for gravship destinations
         private static AccessTools.FieldRef<object> vgeLaunchStateField;
         private static AccessTools.FieldRef<object, PlanetTile> vgeLaunchStateTargetTileField;
@@ -330,30 +326,6 @@ namespace Multiplayer.Compat
                 initiateTakeoffMethod = AccessTools.DeclaredMethod(
                     typeof(WorldComponent_GravshipController), "InitiateTakeoff");
                 validSubstructureProperty = AccessTools.DeclaredProperty(typeof(Building_GravEngine), "ValidSubstructure");
-            }
-
-            #endregion
-
-            #region Mod settings sync (orbitalObjectsMultiplier)
-
-            {
-                // orbitalObjectsMultiplier is a per-player mod setting that affects
-                // WorldComponent_LocationGenerator.WorldComponentTick via transpiler.
-                // If host and client have different values, world RNG state diverges.
-                // Force a consistent value (default 2.0) during world tick in MP.
-                var settingsType = AccessTools.TypeByName("VanillaGravshipExpanded.GravshipsMod_Settings");
-                orbitalObjectsMultiplierField = AccessTools.StaticFieldRefAccess<float>(
-                    AccessTools.DeclaredField(settingsType, "orbitalObjectsMultiplier"));
-
-                MpCompat.harmony.Patch(
-                    AccessTools.DeclaredMethod(typeof(WorldComponent_LocationGenerator), "WorldComponentTick"),
-                    prefix: new HarmonyMethod(typeof(VanillaGravshipExpanded), nameof(PreLocationGeneratorTick)),
-                    postfix: new HarmonyMethod(typeof(VanillaGravshipExpanded), nameof(PostLocationGeneratorTick)));
-
-                MpCompat.harmony.Patch(
-                    AccessTools.DeclaredMethod(typeof(WorldComponent_LocationGenerator), "GenerateUntilTarget", new[] { typeof(PlanetLayer) }),
-                    prefix: new HarmonyMethod(typeof(VanillaGravshipExpanded), nameof(PreLocationGeneratorTick)),
-                    postfix: new HarmonyMethod(typeof(VanillaGravshipExpanded), nameof(PostLocationGeneratorTick)));
             }
 
             #endregion
@@ -795,28 +767,6 @@ namespace Multiplayer.Compat
                     break;
                 }
             }
-        }
-
-        /// <summary>
-        /// Force orbitalObjectsMultiplier to its default value during
-        /// WorldComponent_LocationGenerator methods in MP, so host and client
-        /// produce identical results regardless of per-player mod settings.
-        /// </summary>
-        private static void PreLocationGeneratorTick()
-        {
-            if (!MP.IsInMultiplayer)
-                return;
-
-            savedMultiplier = orbitalObjectsMultiplierField();
-            orbitalObjectsMultiplierField() = 2f; // orbitalObjectsMultiplierBase default
-        }
-
-        private static void PostLocationGeneratorTick()
-        {
-            if (!MP.IsInMultiplayer)
-                return;
-
-            orbitalObjectsMultiplierField() = savedMultiplier;
         }
 
         private static void PreOxygenGizmoOnGUI(Gizmo_Slider __instance)


### PR DESCRIPTION
## Summary
- Remove prefix/postfix that forced `orbitalObjectsMultiplier` to hardcoded default (2.0) during `WorldComponentTick` and `GenerateUntilTarget`
- Compat patches should not override player mod settings — players are responsible for matching their own settings

Per Sokyran's review feedback.

## Test plan
- [x] Build succeeds (0 warnings, 0 errors)
- [x] In-game: VGE loads without errors
- [x] MP: no desync with matching settings across players

🤖 Generated with [Claude Code](https://claude.com/claude-code)