### PR TITLE
fix(VGE): remove gravship naming dialog sync (now in MP)

### DIFF
--- a/Source/Mods/VanillaGravshipExpanded.cs
+++ b/Source/Mods/VanillaGravshipExpanded.cs
@@ -378,21 +378,6 @@ namespace Multiplayer.Compat
 
             #endregion
 
-            #region Gravship naming dialog sync
-
-            {
-                // Dialog_NamePlayerGravship is created from UpdateSubstructureIfNeeded during tick.
-                // Each client can type and submit a different name independently.
-                // Sync the Named method and close the dialog on all clients.
-                MpCompat.harmony.Patch(
-                    AccessTools.DeclaredMethod(typeof(Dialog_NamePlayerGravship), "Named"),
-                    prefix: new HarmonyMethod(typeof(VanillaGravshipExpanded), nameof(PreGravshipNamed)));
-
-                MP.RegisterSyncMethod(typeof(VanillaGravshipExpanded), nameof(SyncedGravshipNamed));
-            }
-
-            #endregion
-
             #region Gizmo_OxygenProvider
 
             {
@@ -759,43 +744,6 @@ namespace Multiplayer.Compat
             }
         }
 
-        /// <summary>
-        /// Intercept Dialog_NamePlayerGravship.Named to sync the gravship name.
-        /// Without this, each client can submit a different name independently.
-        /// </summary>
-        private static bool PreGravshipNamed(Window __instance, string s)
-        {
-            if (!MP.IsInMultiplayer)
-                return true;
-
-            // Get the engine from the dialog via reflection
-            var engineField = AccessTools.Field(typeof(Dialog_NamePlayerGravship), "engine");
-            if (engineField?.GetValue(__instance) is Building_GravEngine engine)
-            {
-                if (!MP.IsExecutingSyncCommand)
-                    SyncedGravshipNamed(engine, s);
-            }
-
-            return false;
-        }
-
-
-        private static void SyncedGravshipNamed(Building_GravEngine engine, string name)
-        {
-            engine.RenamableLabel = name;
-            engine.nameHidden = false;
-            Messages.Message("PlayerGravshipGainsName".Translate(name), MessageTypeDefOf.TaskCompletion, false);
-
-            // Close the naming dialog on all clients
-            for (var i = Find.WindowStack.Windows.Count - 1; i >= 0; i--)
-            {
-                if (Find.WindowStack.Windows[i] is Dialog_NamePlayerGravship)
-                {
-                    Find.WindowStack.Windows[i].Close();
-                    break;
-                }
-            }
-        }
 
         /// <summary>
         /// Force orbitalObjectsMultiplier to its default value during


### PR DESCRIPTION
## Summary
- Remove `PreGravshipNamed` prefix and `SyncedGravshipNamed` method from VGE compat patch
- Auto-popup suppression is now handled by the MP mod (rwmt/Multiplayer#873 — prefix on `UpdateSubstructureIfNeeded`)
- Manual rename sync via `IRenameable` is already handled generically by MP's `SyncMethods`
- Net change: -52 lines

## Dependencies
- Requires rwmt/Multiplayer#873 (suppress gravship naming dialog in MP)

## Test plan
- [x] Deploy both MP and compat DLLs together
- [x] Verify naming dialog does not auto-popup
- [x] Verify manual rename via inspect tab syncs
- [x] Verify no desync from naming flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)