### PR TITLE
fix(VGE): replace oxygen gizmo sync fields with sync methods

### DIFF
--- a/Source/Mods/VanillaGravshipExpanded.cs
+++ b/Source/Mods/VanillaGravshipExpanded.cs
@@ -34,9 +34,9 @@ namespace Multiplayer.Compat
 
         // Gizmo_OxygenProvider
         private static Type oxygenGizmoType;
-        private static AccessTools.FieldRef<object, object> oxygenProviderFromGizmo;
-        private static ISyncField oxygenRechargeAtField;
-        private static ISyncField oxygenAutoRechargeField;
+        private static AccessTools.FieldRef<object, ThingComp> oxygenProviderFromGizmo;
+        private static ISyncField oxygenTargetValuePctField;
+        private static AccessTools.FieldRef<object, Gizmo_Slider> oxygenGizmoFromComp;
 
         // Building_VacBarrier_Recolorable color sync
         private static Type vacBarrierRecolorableType;
@@ -369,13 +369,17 @@ namespace Multiplayer.Compat
 
             {
                 var compType = AccessTools.TypeByName("VanillaGravshipExpanded.CompApparelOxygenProvider");
-                oxygenRechargeAtField = MP.RegisterSyncField(compType, "rechargeAtCharges").SetBufferChanges();
-                oxygenAutoRechargeField = MP.RegisterSyncField(compType, "automaticRechargeEnabled");
+                MP.RegisterSyncMethod(AccessTools.PropertySetter(compType, "AutomaticRechargeEnabled"));
 
                 oxygenGizmoType = AccessTools.TypeByName("VanillaGravshipExpanded.Gizmo_OxygenProvider");
-                oxygenProviderFromGizmo = AccessTools.FieldRefAccess<object>(oxygenGizmoType, "oxygenProvider");
+                oxygenProviderFromGizmo = AccessTools.FieldRefAccess<ThingComp>(oxygenGizmoType, "oxygenProvider");
+                oxygenGizmoFromComp = AccessTools.FieldRefAccess<Gizmo_Slider>(compType, "oxygenConfigurationGizmo");
 
-                // Watch both fields around GizmoOnGUI with explicit WatchBegin/WatchEnd.
+                oxygenTargetValuePctField = MP.RegisterSyncField(oxygenGizmoType, "targetValuePct").SetBufferChanges();
+                AccessTools.Field(oxygenTargetValuePctField.GetType(), "targetType")
+                    .SetValue(oxygenTargetValuePctField, oxygenGizmoType);
+                MP.RegisterSyncWorker<Gizmo_Slider>(SyncOxygenGizmo, oxygenGizmoType);
+
                 MpCompat.harmony.Patch(
                     AccessTools.DeclaredMethod(typeof(Gizmo_Slider), nameof(Gizmo_Slider.GizmoOnGUI)),
                     prefix: new HarmonyMethod(typeof(VanillaGravshipExpanded), nameof(PreOxygenGizmoOnGUI)),
@@ -774,10 +778,8 @@ namespace Multiplayer.Compat
             if (!MP.IsInMultiplayer || __instance.GetType() != oxygenGizmoType)
                 return;
 
-            var comp = oxygenProviderFromGizmo(__instance);
             MP.WatchBegin();
-            oxygenRechargeAtField.Watch(comp);
-            oxygenAutoRechargeField.Watch(comp);
+            oxygenTargetValuePctField.Watch(__instance);
         }
 
         private static void PostOxygenGizmoOnGUI(Gizmo_Slider __instance)
@@ -786,6 +788,19 @@ namespace Multiplayer.Compat
                 return;
 
             MP.WatchEnd();
+        }
+
+        private static void SyncOxygenGizmo(SyncWorker sync, ref Gizmo_Slider gizmo)
+        {
+            if (sync.isWriting)
+            {
+                sync.Write(oxygenProviderFromGizmo(gizmo));
+            }
+            else
+            {
+                var comp = sync.Read<ThingComp>();
+                gizmo = oxygenGizmoFromComp(comp);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- Replace sync field + watch on comp fields (`rechargeAtCharges`, `automaticRechargeEnabled`) with sync method for the toggle and `targetValuePct` sync on the gizmo for the slider
- Add SyncWorker to serialize the oxygen gizmo via its backing comp

## Root cause
The old approach synced `rechargeAtCharges` on the comp, but `Gizmo_Slider.targetValuePct` (a private cache in the base class) overwrites the comp field every frame via `Target = targetValuePct`, defeating the sync. This is the same pattern the MP mod itself uses for `GeneGizmo_Resource` and `ActivityGizmo` — sync the gizmo's `targetValuePct` directly.

## Approach
- **Toggle** (`AutomaticRechargeEnabled`): `RegisterSyncMethod` on the property setter — discrete event, no need for field watching
- **Slider** (`targetValuePct`): `RegisterSyncField` with `SetBufferChanges()` on the gizmo, plus a `SyncWorker` and `targetType` override (the compat API resolves to the declaring base type)

Matches review item S9: "All of this should be easy to do with just sync methods, sync fields are just an extra overhead."

## Test plan
- [x] Builds cleanly
- [x] Manual in-game test: slider and toggle sync between host and client
- [x] No desync after normal play

🤖 Generated with [Claude Code](https://claude.com/claude-code)