### PR TITLE
Adaptive Storage Framework: isolate spawn-time graphic Rand

### DIFF
--- a/Source/Mods/AdaptiveStorageFramework.cs
+++ b/Source/Mods/AdaptiveStorageFramework.cs
@@ -1,0 +1,43 @@
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Adaptive Storage Framework by bbradson</summary>
+    /// <see href="https://github.com/bbradson/Adaptive-Storage-Framework"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=3033901359"/>
+    [MpCompatFor("adaptive.storage.framework")]
+    class AdaptiveStorageFramework
+    {
+        public AdaptiveStorageFramework(ModContentPack mod)
+        {
+            // Deferred — AS's ThingExtensions cctor reads DefDatabase<ThingDef>
+            // and throws if it's empty; mod-ctor is too early. After LongEvent
+            // finishes DefDatabase is loaded.
+            LongEventHandler.ExecuteWhenFinished(() => MpCompatPatchLoader.LoadPatch(this));
+        }
+
+        // Isolate spawn-time graphic randomization (MinifiedThing graphic chain
+        // reaches Graphic_Random.get_MatSingle which consumes Verse.Rand) from
+        // the seeded Map.FinalizeLoading scope. Both entry points need the wrap:
+        //   - InitializeStoredThings: bulk re-add when the container spawns
+        //   - Notify_ItemRegisteredAtCell: per-item add via the ThingGrid.
+        //     RegisterInCell transpiler hook (fires on every item spawn that
+        //     lands in an AS storage cell)
+        [MpCompatPrefix("AdaptiveStorage.ThingClass", "InitializeStoredThings")]
+        [MpCompatPrefix("AdaptiveStorage.ThingClass", "Notify_ItemRegisteredAtCell")]
+        private static void PreStoredThingsChange(Thing __instance, ref bool __state)
+        {
+            Rand.PushState(__instance.thingIDNumber);
+            __state = true;
+        }
+
+        [MpCompatFinalizer("AdaptiveStorage.ThingClass", "InitializeStoredThings")]
+        [MpCompatFinalizer("AdaptiveStorage.ThingClass", "Notify_ItemRegisteredAtCell")]
+        private static void PostStoredThingsChange(bool __state)
+        {
+            if (__state)
+                Rand.PopState();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a compat patch for `adaptive.storage.framework` (by bbradson) wrapping spawn-time graphic-randomization in `Rand.PushState(thingIDNumber)` / `PopState` so it can't perturb MP's `SeedMapFinalizeLoading` seeded scope during host's `SaveAndReload`.
- `LoadPatch` is deferred via `LongEventHandler.ExecuteWhenFinished` to avoid triggering AS's `ThingExtensions` cctor before `DefDatabase` is populated.

## The bug
Adaptive Storage Framework's item-graphic code reaches `Verse.Graphic_Random.get_MatSingle` during spawn, which consumes `Verse.Rand` to pick a random material variant. Two entry points trigger this chain:

1. **`AdaptiveStorage.ThingClass.InitializeStoredThings`** — bulk re-add when a storage container itself spawns
2. **`AdaptiveStorage.ThingClass.Notify_ItemRegisteredAtCell`** — per-item hook fired by [AS's transpiler on `ThingGrid.RegisterInCell`](https://github.com/bbradson/Adaptive-Storage-Framework/blob/main/Source/AdaptiveStorage/HarmonyPatches/RegisteredAtThingGridEvent.cs) for every item spawn landing in an AS storage cell

Full stack (captured from probe instrumentation on a reproducing session):

```
Verse.Rand.Range
  Verse.Graphic_Random.get_MatSingle
    Verse.Graphic.get_Shader
      Verse.GraphicData.GraphicColoredFor
        Verse.Thing.get_DefaultGraphic
          Verse.Thing.get_Graphic
            RimWorld.MinifiedThing.get_Graphic
              AdaptiveStorage.ItemGraphicWorker.GetGraphicFor
                AdaptiveStorage.StorageRenderer.SetPrintDataDirty
                  AdaptiveStorage.StorageRenderer.AssignThingGraphic
                    AdaptiveStorage.ThingCollection.Add
                      AdaptiveStorage.ThingClass.InitializeStoredThings
                        AdaptiveStorage.ThingClass.OnSpawn
                          → Map.FinalizeLoading → SaveLoad.LoadInMainThread → SaveAndReload
```

During host's in-process `SaveAndReload` the spawn-order of these Rand calls relative to `RoomTempTracker.RegenerateEqualizeCells.Shuffle` differs from the client's fresh-process load (same 8174 things spawned, different ordering). Both pull from the same `SeedMapFinalizeLoading`-pushed seed, but at different iteration counts, producing divergent `equalizeCells` per room. Within ~120 ticks the temperature drift propagates into a `FreezeManager.DoIceMelting` `Rand.Chance` short-circuit and the main RNG stream desyncs.

## The fix
Wrap both entry points with `Rand.PushState(__instance.thingIDNumber)` / `PopState` (MP-only). Same pattern as [MP's own `SeedPawnGraphics`](https://github.com/rwmt/Multiplayer/blob/dev/Source/Client/Patches/Seeds.cs#L189-L210) for `PawnRenderer.SetAllGraphicsDirty`. The seed is stable across save/load and identical across clients, so each container picks the same graphic variant every time it spawns — no functional change.

## Why `LoadPatch` is deferred
AS's [`ThingExtensions`](https://github.com/bbradson/Adaptive-Storage-Framework/blob/main/Source/AdaptiveStorage/Utility/ThingExtensions.cs#L138-L146) has a static initializer that reads `DefDatabase<ThingDef>.AllDefsListForReading` and throws if the list is empty. Calling `MpCompatPatchLoader.LoadPatch(this)` in the mod constructor runs early enough that Harmony's patch installation on AS methods transitively triggers the cctor before `DefDatabase` is populated. The cctor throws once, the failure is cached, and every subsequent AS extension-method call rethrows `TypeInitializationException` — tens of thousands of errors per load. Deferring via `LongEventHandler.ExecuteWhenFinished` guarantees `DefDatabase` is loaded when Harmony touches AS.

## Test plan
- [x] Builds cleanly (`dotnet build Source/Multiplayer_Compat.csproj -c Release`)
- [x] Deploy to `D:\Steam\steamapps\workshop\content\294100\1629973374\1.6\Assemblies\Multiplayer_Compat.dll`
- [x] Game loads cleanly (no `ThingExtensions` / `TypeInitializationException` flood)
- [x] Manual MP repro: host loads a save with AS containers + stored items, client joins. Previously reproducing `equalizeCells` shuffle desync no longer fires.
- [x] Visual inspection in SP — storage containers render correctly (deterministic graphic variants per container)

## Notes
- Does not depend on `References/AdaptiveStorageFramework.dll` — uses string-named method resolution throughout, so it stays in `Source/Mods/` rather than `Source_Referenced/`.
- Gate is `[MpCompatFor("adaptive.storage.framework")]` — patch is inert for players without AS installed.
- Companion mod `Reel's Expanded Storage` (`reel.expanded.storage`) depends on AS Framework and shares the same code path; this patch covers it implicitly.