### PR TITLE
Adaptive Storage Framework: skip main-thread graphic resolve under MP

### DIFF
--- a/Source/Mods/AdaptiveStorageFramework.cs
+++ b/Source/Mods/AdaptiveStorageFramework.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using Multiplayer.API;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Adaptive Storage Framework by bbradson</summary>
+    /// <see href="https://github.com/bbradson/Adaptive-Storage-Framework"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=3033901359"/>
+    [MpCompatFor("adaptive.storage.framework")]
+    class AdaptiveStorageFramework
+    {
+        private static readonly MethodInfo IsInMainThreadGetter
+            = AccessTools.PropertyGetter(typeof(UnityData), nameof(UnityData.IsInMainThread));
+
+        public AdaptiveStorageFramework(ModContentPack mod)
+        {
+            // AS's ThingExtensions cctor reads DefDatabase<ThingDef>
+            LongEventHandler.ExecuteWhenFinished(() => MpCompatPatchLoader.LoadPatch(this));
+        }
+
+        // Mirrors bbradson/Adaptive-Storage-Framework#30
+        [MpCompatTranspiler("AdaptiveStorage.StorageRenderer", "SetPrintDataDirty")]
+        private static IEnumerable<CodeInstruction> SetPrintDataDirty_Transpiler(IEnumerable<CodeInstruction> insts)
+        {
+            foreach (var inst in insts)
+            {
+                if (inst.Calls(IsInMainThreadGetter))
+                    yield return new CodeInstruction(OpCodes.Call,
+                        AccessTools.Method(typeof(AdaptiveStorageFramework), nameof(IsInMainThreadAndNotMp)));
+                else
+                    yield return inst;
+            }
+        }
+
+        private static bool IsInMainThreadAndNotMp() => UnityData.IsInMainThread && !MP.enabled;
+    }
+}


### PR DESCRIPTION
## Summary

Mirrors [bbradson/Adaptive-Storage-Framework#30](https://github.com/bbradson/Adaptive-Storage-Framework/pull/30) as a compat-side stopgap, since AS Framework releases infrequently.

`StorageRenderer.SetPrintDataDirty` takes a main-thread fast path that calls `itemGraphic.Worker.GetGraphicFor`, which chains into `Graphic_Random.get_MatSingle` and consumes `Verse.Rand`. `SaveAndReload` runs on the main thread; a fresh process's load runs off-thread via `LongEventHandler.QueueLongEvent doAsynchronously`. Host and client therefore consume different amounts of `Rand` from the seeded `Map.FinalizeLoading` scope, which desyncs the next downstream consumer (`RoomTempTracker.equalizeCells.Shuffle`, then `FreezeManager.DoIceMelting`).

Transpile `SetPrintDataDirty` so the `UnityData.IsInMainThread` check becomes `IsInMainThread && !MP.enabled`, forcing the deferred path symmetrically on host and client when an MP session is active. Solo behavior unchanged.

## Test plan

- [x] Builds clean against current MP API
- [ ] Host saves & reloads in MP, client joins after — no desync at next storage-cell affecting tick (was reproducing in `FreezeManager.DoIceMelting`)
- [ ] Solo (MP not loaded) — `IsInMainThread && !MP.enabled` stays true, original fast path runs, no rendering regression