### PR TITLE
fix(vge): sync Command_Ritual.ProcessInput for gravship launch ritual

### DIFF
--- a/Source_Referenced/VanillaGravshipExpanded.cs
+++ b/Source_Referenced/VanillaGravshipExpanded.cs
@@ -192,6 +192,12 @@ namespace Multiplayer.Compat
             #region VGE launch flow fix
 
             {
+                MpCompat.harmony.Patch(
+                    AccessTools.DeclaredMethod(typeof(Command_Ritual), nameof(Command_Ritual.ProcessInput)),
+                    prefix: new HarmonyMethod(typeof(VanillaGravshipExpanded), nameof(PreCommandRitualProcessInput_SyncIfGravshipLaunch)));
+
+                MP.RegisterSyncMethod(typeof(VanillaGravshipExpanded), nameof(SyncedShowRitualBeginWindow));
+
                 // VGE replaces the vanilla gravship launch flow: instead of tile picker → launch,
                 // it does tile picker → ritual → launch. VGE intercepts ShowRitualBeginWindow to
                 // insert a tile selection step before the ritual.
@@ -409,6 +415,24 @@ namespace Multiplayer.Compat
         {
             if (MP.IsInMultiplayer && !inSyncedTileSelectedFlow)
                 Dialog_BeginRitual_ShowRitualBeginWindow_Patch.state = null;
+        }
+
+        private static bool PreCommandRitualProcessInput_SyncIfGravshipLaunch(Command_Ritual __instance)
+        {
+            if (!MP.IsInMultiplayer)
+                return true;
+            if (MP.IsExecutingSyncCommand)
+                return true;
+            if (!__instance.ritual.def.IsGravshipLaunch())
+                return true;
+
+            SyncedShowRitualBeginWindow(__instance.ritual, __instance.targetInfo);
+            return false;
+        }
+
+        private static void SyncedShowRitualBeginWindow(Precept_Ritual ritual, TargetInfo targetInfo)
+        {
+            ritual.ShowRitualBeginWindow(targetInfo);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
The pilot console's "Launch..." button is the vanilla `Command_Ritual` gizmo emitted by [`Precept_Ritual.GetGizmoFor`](https://github.com/rwmt/Multiplayer-Compatibility/issues). Its `ProcessInput` calls `Precept_Ritual.ShowRitualBeginWindow` directly from UI context, which VGE's prefix intercepts to set the static `Dialog_BeginRitual_ShowRitualBeginWindow_Patch.state` and open the tile picker via `StartChoosingDestination_NewTemp`.

Because the click happens on one client only, VGE state is set on the clicker only. The tile picker propagates to other clients via MP's `GravshipTravelSession`, but on non-clickers `state` stays null, so `SyncedGravshipTileSelected` bails at the null-check ([compat L447-449](https://github.com/rwmt/Multiplayer-Compatibility/blob/master/Source_Referenced/VanillaGravshipExpanded.cs#L447-L449)) when a tile is picked.

## Approach
Harmony prefix on `Command_Ritual.ProcessInput`. Conditions to intercept: MP active, not executing sync, ritual is a gravship launch. If matched, call a synced `ShowRitualBeginWindow` and return false. Sync replay runs `ShowRitualBeginWindow` on every client → VGE's prefix fires everywhere → state is set everywhere → downstream tile selection sync works as designed.

```csharp
private static bool PreCommandRitualProcessInput_SyncIfGravshipLaunch(Command_Ritual __instance)
{
    if (!MP.IsInMultiplayer) return true;
    if (MP.IsExecutingSyncCommand) return true;
    if (!__instance.ritual.def.IsGravshipLaunch()) return true;

    SyncedShowRitualBeginWindow(__instance.ritual, __instance.targetInfo);
    return false;
}

private static void SyncedShowRitualBeginWindow(Precept_Ritual ritual, TargetInfo targetInfo)
{
    ritual.ShowRitualBeginWindow(targetInfo);
}
```

## Args dropped from sync
- `obligation` (RitualObligation) and `selectedPawn` (Pawn): IL inspection of `Command_Ritual.ProcessInput` shows both are always `null` when invoked from the gizmo.
- `forcedForRole` (Dictionary<string, Pawn>): typically empty when launched from the gizmo. If a flow requires preset roles, extend the sync signature.

## Trade-off
Returning false skips `base.Command.ProcessInput`, losing the button-click sound on the clicker. Acceptable for sync correctness; can restore via reflection if the UX loss is real.

## Test plan
- [x] Builds cleanly (Source + Source_Referenced)
- [ ] MP: host clicks pilot console Launch... → both clients open tile picker, both pick reaches ritual + launch in lockstep
- [ ] MP: non-host clicks Launch... → same
- [ ] MP: cancel tile picker on one client → both clear state
- [ ] MP: non-gravship ritual gizmo (e.g. social ritual) still works normally (prefix bails on `!IsGravshipLaunch`)
- [ ] SP: Launch button still works