### PR TITLE
Fix Smarter Construction compat for 1.6 cache refactor (#598)

### DIFF
--- a/Source/Mods/SmarterConstruction.cs
+++ b/Source/Mods/SmarterConstruction.cs
@@ -1,74 +1,181 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Reflection;
 using HarmonyLib;
 using Verse;
 
-namespace Multiplayer.Compat
+namespace Multiplayer.Compat;
+
+/// <summary>Smarter Construction by Hultis</summary>
+/// <see href="https://github.com/dhultgren/rimworld-smarter-construction"/>
+/// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2202185773"/>
+[MpCompatFor("dhultgren.smarterconstruction")]
+internal class SmarterConstruction
 {
-    /// <summary>Smarter Construction by Hultis</summary>
-    /// <see href="https://github.com/dhultgren/rimworld-smarter-construction"/>
-    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=2202185773"/>
-    [MpCompatFor("dhultgren.smarterconstruction")]
-    class SmarterConstruction
+    // Patch_WorkGiver_Scanner_GetPriority
+    private static AccessTools.FieldRef<IDictionary> workGiverScannerCacheField;
+
+    // Pre-1.6 static caches
+    // ClosedRegionDetector
+    private static AccessTools.FieldRef<object> closedRegionDetectorCacheField;
+
+    // EncloseThingsCache
+    private static AccessTools.FieldRef<object, IDictionary> encloseThingsCacheField;
+
+    // PawnPositionCache
+    private static FieldInfo positionsCacheField;
+    private static FieldInfo lastPositionsCacheCleanupField;
+
+    // 1.6+ per-map MapComponent caches
+    private static MethodInfo encloseThingsGetCacheMethod;
+    private static MethodInfo pawnPositionGetCacheMethod;
+    private static FieldInfo encloseThingsMapCacheField;
+    private static FieldInfo pawnPositionMapCacheField;
+    private static FieldInfo pawnPositionLastCleanupField;
+
+    private static Action clearSecondaryCaches;
+
+    // WorkGiver_ConstructFinishFrames_JobOnThing
+    private static AccessTools.FieldRef<int> constructFinishFrameCurrentTickField;
+
+    public SmarterConstruction(ModContentPack mod)
     {
-        // Patch_WorkGiver_Scanner_GetPriority
-        private static AccessTools.FieldRef<IDictionary> workGiverScannerCacheField;
-        // ClosedRegionDetector
-        private static AccessTools.FieldRef<object> closedRegionDetectorCacheField;
-        // EncloseThingsCache
-        private static AccessTools.FieldRef<object, IDictionary> encloseThingsCacheField;
-        // PawnPositionCache
-        private static FieldInfo positionsCacheField;
-        private static FieldInfo lastPositionsCacheCleanupField;
-        // WorkGiver_ConstructFinishFrames_JobOnThing
-        private static AccessTools.FieldRef<int> constructFinishFrameCurrentTickField;
+        var type = AccessTools.TypeByName("SmarterConstruction.Patches.Patch_WorkGiver_Scanner_GetPriority");
 
-        public SmarterConstruction(ModContentPack mod)
+        // RNG
         {
-            var type = AccessTools.TypeByName("SmarterConstruction.Patches.Patch_WorkGiver_Scanner_GetPriority");
-
-            // RNG
-            {
-                var field = AccessTools.Field(type, "random");
-
-                field.SetValue(null, PatchingUtilities.RandRedirector.Instance);
-            }
-
-            // Cache
-            {
-                workGiverScannerCacheField = AccessTools.StaticFieldRefAccess<IDictionary>(AccessTools.DeclaredField(type, "cache"));
-
-                closedRegionDetectorCacheField = AccessTools.StaticFieldRefAccess<object>(
-                    AccessTools.DeclaredField("SmarterConstruction.Core.ClosedRegionDetector:cache"));
-                encloseThingsCacheField = AccessTools.FieldRefAccess<IDictionary>("SmarterConstruction.Core.EncloseThingsCache:cache");
-
-                type = AccessTools.TypeByName("SmarterConstruction.Core.PawnPositionCache");
-                // Harmony seems to fail to create FieldRef<T> on those 2, so just gonna use FieldInfo instead.
-                positionsCacheField = AccessTools.DeclaredField(type, "positionCache");
-                lastPositionsCacheCleanupField = AccessTools.DeclaredField(type, "lastCacheCleanup");
-
-                constructFinishFrameCurrentTickField = AccessTools.StaticFieldRefAccess<int>(
-                    AccessTools.DeclaredField("SmarterConstruction.Patches.WorkGiver_ConstructFinishFrames_JobOnThing:currentTick"));
-
-                MpCompat.harmony.Patch(AccessTools.DeclaredMethod(typeof(GameComponentUtility), nameof(GameComponentUtility.FinalizeInit)),
-                    postfix: new HarmonyMethod(typeof(SmarterConstruction), nameof(ClearCache)));
-            }
+            var field = AccessTools.Field(type, "random");
+            field.SetValue(null, PatchingUtilities.RandRedirector.Instance);
         }
 
-        private static void ClearCache()
+        // Cache
         {
-            workGiverScannerCacheField().Clear();
-            // ClosedRegionDetector.cache.cache.Clear();
-            encloseThingsCacheField(closedRegionDetectorCacheField()).Clear();
+            workGiverScannerCacheField = AccessTools.StaticFieldRefAccess<IDictionary>(
+                AccessTools.DeclaredField(type, "cache"));
 
-            ((IDictionary)positionsCacheField.GetValue(null)).Clear();
-            // Reset the last cleanup tick field, as if we load an older save - it'll have to wait until the previously assigned tick to cleanup.
-            lastPositionsCacheCleanupField.SetValue(null, 0);
+            // SC 1.6 moved enclose/pawn caches from static fields to per-map MapComponents.
+            if (UsesMapComponentLayout())
+            {
+                InitMapComponentCaches();
+                clearSecondaryCaches = ClearMapComponentCaches;
+            }
+            else
+            {
+                InitStaticCaches();
+                clearSecondaryCaches = ClearStaticCaches;
+            }
 
-            // Small chance it could cause issues when the loaded game is on the same tick as the tick stored by this field
-            constructFinishFrameCurrentTickField() = -1;
-            // Since we set the current tick to -1 (as opposed to 0), there's no chance unless something
-            // is very wrong for `thingsUpdatedThisTick` field to be valid and kept by the mod. No need to clean it.
+            constructFinishFrameCurrentTickField = AccessTools.StaticFieldRefAccess<int>(
+                AccessTools.DeclaredField(
+                    "SmarterConstruction.Patches.WorkGiver_ConstructFinishFrames_JobOnThing:currentTick"));
+
+            MpCompat.harmony.Patch(
+                AccessTools.DeclaredMethod(typeof(GameComponentUtility), nameof(GameComponentUtility.FinalizeInit)),
+                postfix: new HarmonyMethod(typeof(SmarterConstruction), nameof(ClearCache)));
+        }
+    }
+
+    private static bool UsesMapComponentLayout()
+    {
+        var encloseThingsCacheType = AccessTools.TypeByName("SmarterConstruction.Core.EncloseThingsCache");
+        return encloseThingsCacheType != null
+               && typeof(MapComponent).IsAssignableFrom(encloseThingsCacheType)
+               && AccessTools.Method(
+                   encloseThingsCacheType,
+                   "GetCache",
+                   new[]
+                   {
+                       typeof(Map)
+                   }) != null;
+    }
+
+    private static void InitStaticCaches()
+    {
+        closedRegionDetectorCacheField = AccessTools.StaticFieldRefAccess<object>(
+            AccessTools.DeclaredField("SmarterConstruction.Core.ClosedRegionDetector:cache"));
+        encloseThingsCacheField =
+            AccessTools.FieldRefAccess<IDictionary>("SmarterConstruction.Core.EncloseThingsCache:cache");
+
+        var pawnPositionCacheType = AccessTools.TypeByName("SmarterConstruction.Core.PawnPositionCache");
+        // Harmony seems to fail to create FieldRef<T> on those 2, so just gonna use FieldInfo instead.
+        positionsCacheField = AccessTools.DeclaredField(pawnPositionCacheType, "positionCache");
+        lastPositionsCacheCleanupField = AccessTools.DeclaredField(pawnPositionCacheType, "lastCacheCleanup");
+    }
+
+    private static void InitMapComponentCaches()
+    {
+        var encloseThingsCacheType = AccessTools.TypeByName("SmarterConstruction.Core.EncloseThingsCache");
+        var pawnPositionCacheType = AccessTools.TypeByName("SmarterConstruction.Core.PawnPositionCache");
+
+        encloseThingsGetCacheMethod = AccessTools.Method(
+            encloseThingsCacheType,
+            "GetCache",
+            new[]
+            {
+                typeof(Map)
+            });
+        pawnPositionGetCacheMethod = AccessTools.Method(
+            pawnPositionCacheType,
+            "GetCache",
+            new[]
+            {
+                typeof(Map)
+            });
+
+        encloseThingsMapCacheField = AccessTools.DeclaredField(encloseThingsCacheType, "_cache")
+                                     ?? AccessTools.DeclaredField(encloseThingsCacheType, "cache");
+        pawnPositionMapCacheField = AccessTools.DeclaredField(pawnPositionCacheType, "_positionCache")
+                                    ?? AccessTools.DeclaredField(pawnPositionCacheType, "positionCache");
+        pawnPositionLastCleanupField = AccessTools.DeclaredField(pawnPositionCacheType, "_lastCacheCleanup")
+                                       ?? AccessTools.DeclaredField(pawnPositionCacheType, "lastCacheCleanup");
+    }
+
+    private static void ClearCache()
+    {
+        workGiverScannerCacheField().Clear();
+        clearSecondaryCaches();
+
+        // Small chance it could cause issues when the loaded game is on the same tick as the tick stored by this field
+        constructFinishFrameCurrentTickField() = -1;
+        // Since we set the current tick to -1 (as opposed to 0), there's no chance unless something
+        // is very wrong for `thingsUpdatedThisTick` field to be valid and kept by the mod. No need to clean it.
+    }
+
+    private static void ClearStaticCaches()
+    {
+        encloseThingsCacheField(closedRegionDetectorCacheField()).Clear();
+
+        ((IDictionary)positionsCacheField.GetValue(null)).Clear();
+        // Reset the last cleanup tick field, as if we load an older save - it'll have to wait until the previously assigned tick to clean up.
+        lastPositionsCacheCleanupField.SetValue(null, 0);
+    }
+
+    private static void ClearMapComponentCaches()
+    {
+        foreach (var map in Find.Maps)
+        {
+            var encloseThingsCache = encloseThingsGetCacheMethod.Invoke(
+                null,
+                new object[]
+                {
+                    map
+                });
+            if (encloseThingsCache != null)
+            {
+                ((IDictionary)encloseThingsMapCacheField.GetValue(encloseThingsCache)).Clear();
+            }
+
+            var pawnPositionCache = pawnPositionGetCacheMethod.Invoke(
+                null,
+                new object[]
+                {
+                    map
+                });
+            if (pawnPositionCache != null)
+            {
+                ((IDictionary)pawnPositionMapCacheField.GetValue(pawnPositionCache)).Clear();
+                pawnPositionLastCleanupField.SetValue(pawnPositionCache, 0);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Smarter Construction 1.6 refactored its internal caches from static fields to per-map `MapComponent`s. The existing compat patch in [`SmarterConstruction.cs`](Source/Mods/SmarterConstruction.cs) still resolved `ClosedRegionDetector.cache` and other static bindings via `AccessTools.StaticFieldRefAccess`. On current SC 1.6 builds those fields no longer exist, so `DeclaredField` returns null and compat init throws:

```
MPCompat :: Exception loading dhultgren.smarterconstruction: System.ArgumentNullException: Value cannot be null.
Parameter name: fieldInfo
  at HarmonyLib.AccessTools.StaticFieldRefAccess[F] ...
  at Multiplayer.Compat.SmarterConstruction..ctor(ModContentPack mod)
```

Reported in [#598](https://github.com/rwmt/Multiplayer-Compatibility/issues/598).

## Approach

Detect which layout is loaded at init time instead of inferring from a missing static field:

```csharp
private static bool UsesMapComponentLayout()
{
    var encloseThingsCacheType = AccessTools.TypeByName("SmarterConstruction.Core.EncloseThingsCache");
    return encloseThingsCacheType != null
        && typeof(MapComponent).IsAssignableFrom(encloseThingsCacheType)
        && AccessTools.Method(encloseThingsCacheType, "GetCache", new[] { typeof(Map) }) != null;
}
```

- **1.6+ path:** resolve `GetCache(Map)` on `EncloseThingsCache` / `PawnPositionCache`, clear `_cache` / `_positionCache` per map in `Find.Maps`, reset `_lastCacheCleanup` to `0`.
- **Pre-1.6 path:** keep existing static field refs (`ClosedRegionDetector.cache` → nested `EncloseThingsCache.cache`, static `PawnPositionCache` fields).
- Assign `clearSecondaryCaches` once at init (`ClearMapComponentCaches` or `ClearStaticCaches`) so `GameComponentUtility.FinalizeInit` clearing stays branch-free.

Field name fallbacks (`_cache` / `cache`, `_positionCache` / `positionCache`) retained for minor renames within each layout.

## Trade-off

Still uses reflection into private cache fields rather than an upstream SC API (e.g. `Compatibility.ClearCachesForMultiplayer()`). Acceptable for MP Compat; a public clear hook in [rimworld-smarter-construction](https://github.com/dhultgren/rimworld-smarter-construction) would be more stable long-term but is out of scope here.

## Test plan

- [x] Builds cleanly (`Multiplayer_Compat.sln`, Debug)
- [x] Game load: log shows `MPCompat :: Initialized compatibility for dhultgren.smarterconstruction` (no `ArgumentNullException`)
- [x] MP: start/load colony with Smarter Construction enabled; no compat errors on `FinalizeInit`
- [ ] MP: host + client load same save after a prior session (cache clear on `FinalizeInit` does not break construction priority / enclose checks)