### PR TITLE
Run and gun Continued Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ RimFridge | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?
 Rimsential - Spaceports | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=2663999215) [![url][repo]](https://github.com/SomewhereOutInSpace/Rimworld-Spaceports)
 RPG Style Inventory | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=1561221991) [![url][repo]](https://github.com/SandyTheGreat/RPG-Style-Inventory)
 RunAndGun | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=1204108550) [![url][repo]](https://github.com/rheirman/RunAndGun)
+RunAndGun Continued | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=3562365100) [![url][repo]](https://github.com/MemeGoddess/RunAndGun)
 Search and Destroy | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=1467764609) [![url][repo]](https://github.com/rheirman/SearchAndDestroy)
 Signs and Comments | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=2576219203) [![url][repo]](https://github.com/JTJutajoh/RimWorld.Signs)
 Simple Sidearms | [![url][steam]](https://steamcommunity.com/sharedfiles/filedetails/?id=927155256) [![url][repo]](https://github.com/PeteTimesSix/SimpleSidearms)

--- a/Source/Mods/RunandGun.cs
+++ b/Source/Mods/RunandGun.cs
@@ -7,10 +7,8 @@ namespace Multiplayer.Compat
 {
     /// <summary>RunAndGun by roolo</summary>
     /// <see href="https://github.com/rheirman/RunAndGun"/>
-    /// <see href="https://github.com/MemeGoddess/RunAndGun"/>
     /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=1204108550"/>
     [MpCompatFor("roolo.RunAndGun")]
-    [MpCompatFor("memegoddess.RunAndGun")]
     class RunandGun
     {
         public RunandGun(ModContentPack mod)

--- a/Source/Mods/RunandGunContinued.cs
+++ b/Source/Mods/RunandGunContinued.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Verse;
+using HarmonyLib;
+using Multiplayer.API;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>RunAndGun Continued</summary>
+    /// <see href="https://github.com/MemeGoddess/RunAndGun"/>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=3562365100"/>
+    [MpCompatFor("memegoddess.RunAndGun")]
+    class RunandGunContinued
+    {
+        public RunandGunContinued(ModContentPack mod)
+        {
+            MpCompat.RegisterLambdaDelegate("RunAndGun.Harmony.Pawn_DraftController_GetGizmos_Patch", "Postfix", 1);
+            PatchingUtilities.PatchUnityRand("RunAndGun.Harmony.MentalStateHandler_TryStartMentalState:shouldRunAndGun", false);
+        }
+    }
+}


### PR DESCRIPTION
Separate patches for original RunandGun and RunandGun Continued, since the latter requires changes.
Update Readme to add RunandGun Continued as a separate entry.