### PR TITLE
Add Vanilla Plants Flowers compatibility

### DIFF
--- a/Source/Mods/VanillaPlantsFlowers.cs
+++ b/Source/Mods/VanillaPlantsFlowers.cs
@@ -1,0 +1,16 @@
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>Vanilla Plants Expanded - Flowers by Oskar Potocki, Sarg Bjornson</summary>
+    /// <see href="https://github.com/Vanilla-Expanded/VanillaPlantsExpanded-Flowers"/>
+    [MpCompatFor("VanillaExpanded.VPEFlowers")]
+    public class VanillaPlantsFlowers
+    {
+        public VanillaPlantsFlowers(ModContentPack mod)
+        {
+            // Toggle allow sow (1), allow cut (3), verified at f6f891d
+            MpCompat.RegisterLambdaMethod("VanillaPlantsExpandedFlowers.Zone_BloomingFlowerZone", "GetGizmos", 1, 3);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add compatibility for Vanilla Plants Expanded - Flowers
- synchronize the Allow sow and Allow cutting zone toggles

## Root cause
`Zone_BloomingFlowerZone` changes its saved `allowSow` and `allowCut` fields directly from `Command_Toggle` callbacks. Those local UI actions are not covered by Multiplayer's generic designator synchronization.

## Approach
Register `GetGizmos` lambda ordinals 1 and 3, matching the established More Plants and Mushrooms patches. Plant selection and the custom zone designators are already synchronized by Multiplayer and need no extra patch.

## Test plan
- [x] Release build succeeds with zero warnings and errors
- [x] Verify lambda ordinals against source and the shipped Flowers assembly at `f6f891d`
- [x] Deploy the compat DLL to RimWorld 1.6
- [x] In a two-player game, toggle Allow sow from each peer and verify the other peer receives the state change
- [x] In a two-player game, toggle Allow cutting from each peer and verify the other peer receives the state change
- [x] Continue simulation and verify no sync errors or desyncs occur

Manual multiplayer testing was completed successfully by the contributor.