### PR TITLE
Add compatibility for Isekai RPG series (Leveling, Guild Faction, Cre…

### DIFF
--- a/Source/Mods/IsekaiCreatures.cs
+++ b/Source/Mods/IsekaiCreatures.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using HarmonyLib;
+using Multiplayer.API;
+using RimWorld;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>ISEKAI CREATURES ADD-ON by Poupun</summary>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=3757560461"/>
+    [MpCompatFor("Poupun.IsekaiCreaturesAddon")]
+    public class IsekaiCreaturesCompat
+    {
+        private static Type petGizmosPatchType;
+        private static Type sealProviderType;
+        private static Type tameProviderType;
+
+        public IsekaiCreaturesCompat(ModContentPack mod)
+        {
+            petGizmosPatchType = AccessTools.TypeByName("IsekaiCreatures.Taming.Pawn_GetGizmos_Pet_Patch");
+            sealProviderType = AccessTools.TypeByName("IsekaiCreatures.Sealing.FloatMenuOptionProvider_SealCreature");
+            tameProviderType = AccessTools.TypeByName("IsekaiCreatures.Taming.FloatMenuOptionProvider_TameBeast");
+
+            if (petGizmosPatchType != null)
+            {
+                var withDraftToggleMethod = AccessTools.DeclaredMethod(petGizmosPatchType, "WithDraftToggle");
+                if (withDraftToggleMethod != null)
+                {
+                    MpCompat.harmony.Patch(withDraftToggleMethod,
+                        postfix: new HarmonyMethod(typeof(IsekaiCreaturesCompat), nameof(WithDraftTogglePostfix)));
+                    MP.RegisterSyncMethod(typeof(IsekaiCreaturesCompat), nameof(SyncedSetPetDrafted));
+                }
+            }
+
+            if (sealProviderType != null)
+            {
+                var sealMethod = AccessTools.DeclaredMethod(sealProviderType, "GetOptionsFor");
+                if (sealMethod != null)
+                {
+                    MpCompat.harmony.Patch(sealMethod,
+                        postfix: new HarmonyMethod(typeof(IsekaiCreaturesCompat), nameof(SealOptionsPostfix)));
+                    MP.RegisterSyncMethod(typeof(IsekaiCreaturesCompat), nameof(SyncedToggleSealDesignation));
+                }
+            }
+
+            if (tameProviderType != null)
+            {
+                var tameMethod = AccessTools.DeclaredMethod(tameProviderType, "GetOptionsFor");
+                if (tameMethod != null)
+                {
+                    MpCompat.harmony.Patch(tameMethod,
+                        postfix: new HarmonyMethod(typeof(IsekaiCreaturesCompat), nameof(TameOptionsPostfix)));
+                    MP.RegisterSyncMethod(typeof(IsekaiCreaturesCompat), nameof(SyncedToggleTameDesignation));
+                }
+            }
+        }
+
+        #region Pet Drafting
+
+        private static void WithDraftTogglePostfix(ref IEnumerable<Gizmo> __result, Pawn pawn)
+        {
+            if (!MP.IsInMultiplayer || pawn == null || __result == null) return;
+            __result = WrapPetGizmos(__result, pawn);
+        }
+
+        private static IEnumerable<Gizmo> WrapPetGizmos(IEnumerable<Gizmo> gizmos, Pawn pawn)
+        {
+            foreach (var g in gizmos)
+            {
+                if (g is Command_Toggle toggle && toggle.hotKey == KeyBindingDefOf.Command_ColonistDraft)
+                {
+                    toggle.toggleAction = () => SyncedSetPetDrafted(pawn, !pawn.Drafted);
+                }
+                yield return g;
+            }
+        }
+
+        private static void SyncedSetPetDrafted(Pawn pawn, bool drafted)
+        {
+            if (pawn?.drafter != null)
+                pawn.drafter.Drafted = drafted;
+        }
+
+        #endregion
+
+        #region Sealing
+
+        private static void SealOptionsPostfix(ref IEnumerable<FloatMenuOption> __result, Pawn clickedPawn)
+        {
+            if (!MP.IsInMultiplayer || clickedPawn == null || __result == null) return;
+            __result = WrapSealOptions(__result, clickedPawn);
+        }
+
+        private static IEnumerable<FloatMenuOption> WrapSealOptions(IEnumerable<FloatMenuOption> options, Pawn creature)
+        {
+            foreach (var opt in options)
+            {
+                if (opt.action != null)
+                {
+                    opt.action = () => SyncedToggleSealDesignation(creature);
+                }
+                yield return opt;
+            }
+        }
+
+        private static void SyncedToggleSealDesignation(Pawn creature)
+        {
+            if (creature?.Map == null) return;
+            var dm = creature.Map.designationManager;
+            if (dm == null) return;
+
+            var sealDef = DefDatabase<DesignationDef>.GetNamedSilentFail("IsekaiSealCreature");
+            if (sealDef == null) return;
+
+            var d = dm.DesignationOn(creature, sealDef);
+            if (d != null)
+                dm.RemoveDesignation(d);
+            else
+                dm.AddDesignation(new Designation(creature, sealDef));
+        }
+
+        #endregion
+
+        #region Taming
+
+        private static void TameOptionsPostfix(ref IEnumerable<FloatMenuOption> __result, Thing clickedThing)
+        {
+            if (!MP.IsInMultiplayer || clickedThing is not Pawn beast || __result == null) return;
+            __result = WrapTameOptions(__result, beast);
+        }
+
+        private static IEnumerable<FloatMenuOption> WrapTameOptions(IEnumerable<FloatMenuOption> options, Pawn beast)
+        {
+            foreach (var opt in options)
+            {
+                if (opt.action != null)
+                {
+                    opt.action = () => SyncedToggleTameDesignation(beast);
+                }
+                yield return opt;
+            }
+        }
+
+        private static void SyncedToggleTameDesignation(Pawn beast)
+        {
+            if (beast?.Map == null) return;
+            var dm = beast.Map.designationManager;
+            if (dm == null) return;
+
+            var tameDef = DefDatabase<DesignationDef>.GetNamedSilentFail("IsekaiTameBeast");
+            if (tameDef == null) return;
+
+            var d = dm.DesignationOn(beast, tameDef);
+            if (d != null)
+                dm.RemoveDesignation(d);
+            else
+                dm.AddDesignation(new Designation(beast, tameDef));
+        }
+
+        #endregion
+    }
+}

--- a/Source/Mods/IsekaiGuildFaction.cs
+++ b/Source/Mods/IsekaiGuildFaction.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections;
+using System.Reflection;
+using HarmonyLib;
+using Multiplayer.API;
+using RimWorld.Planet;
+using Verse;
+
+namespace Multiplayer.Compat
+{
+    /// <summary>GUILD FACTION ADD-ON by Poupun</summary>
+    /// <see href="https://steamcommunity.com/sharedfiles/filedetails/?id=3718568958"/>
+    [MpCompatFor("Poupun.GuildFactionAddon")]
+    public class IsekaiGuildFactionCompat
+    {
+        private static Type dialogGuildQuestBoardType;
+        private static Type guildQuestBoardWorldCompType;
+        private static PropertyInfo entriesProperty;
+        private static FieldInfo entriesField;
+        private static MethodInfo acceptEntryMethod;
+        private static MethodInfo tryRefreshMethod;
+
+        public IsekaiGuildFactionCompat(ModContentPack mod)
+        {
+            dialogGuildQuestBoardType = AccessTools.TypeByName("GuildFactionAddon.Dialog_GuildQuestBoard");
+            guildQuestBoardWorldCompType = AccessTools.TypeByName("GuildFactionAddon.GuildQuestBoardWorldComponent");
+
+            if (dialogGuildQuestBoardType == null || guildQuestBoardWorldCompType == null)
+            {
+                Log.Warning("[IsekaiMP] GuildFactionAddon types could not be resolved — patches skipped.");
+                return;
+            }
+
+            entriesProperty = AccessTools.Property(guildQuestBoardWorldCompType, "Entries");
+            entriesField = AccessTools.Field(guildQuestBoardWorldCompType, "entries");
+            acceptEntryMethod = AccessTools.DeclaredMethod(dialogGuildQuestBoardType, "AcceptEntry");
+            tryRefreshMethod = AccessTools.DeclaredMethod(guildQuestBoardWorldCompType, "TryRefresh");
+
+            if (acceptEntryMethod != null)
+            {
+                MpCompat.harmony.Patch(acceptEntryMethod,
+                    prefix: new HarmonyMethod(typeof(IsekaiGuildFactionCompat), nameof(AcceptEntryPrefix)));
+                MP.RegisterSyncMethod(typeof(IsekaiGuildFactionCompat), nameof(SyncedAcceptQuestEntry));
+            }
+
+            // Ensure daily quest refresh triggers deterministically in lockstep during game ticks
+            var worldTickMethod = AccessTools.DeclaredMethod(typeof(World), nameof(World.WorldTick));
+            if (worldTickMethod != null && tryRefreshMethod != null)
+            {
+                MpCompat.harmony.Patch(worldTickMethod,
+                    postfix: new HarmonyMethod(typeof(IsekaiGuildFactionCompat), nameof(WorldTickPostfix)));
+            }
+        }
+
+        private static void WorldTickPostfix()
+        {
+            if (Find.TickManager != null && Find.TickManager.TicksGame % 250 == 0)
+            {
+                var comp = Find.World?.GetComponent(guildQuestBoardWorldCompType);
+                if (comp != null && tryRefreshMethod != null)
+                {
+                    tryRefreshMethod.Invoke(comp, [false]);
+                }
+            }
+        }
+
+        private static bool _suppressAcceptEntry = false;
+
+        private static bool AcceptEntryPrefix(object entry)
+        {
+            if (!MP.IsInMultiplayer || _suppressAcceptEntry || entry == null) return true;
+
+            var boardComp = Find.World?.GetComponent(guildQuestBoardWorldCompType);
+            if (boardComp == null) return true;
+
+            var entries = entriesProperty != null
+                ? (IList)entriesProperty.GetValue(boardComp)
+                : (IList)entriesField?.GetValue(boardComp);
+            if (entries == null) return true;
+
+            int index = entries.IndexOf(entry);
+            if (index >= 0)
+            {
+                SyncedAcceptQuestEntry(index);
+                return false;
+            }
+
+            return true;
+        }
+
+        private static void SyncedAcceptQuestEntry(int index)
+        {
+            var boardComp = Find.World?.GetComponent(guildQuestBoardWorldCompType);
+            if (boardComp == null) return;
+
+            var entries = entriesProperty != null
+                ? (IList)entriesProperty.GetValue(boardComp)
+                : (IList)entriesField?.GetValue(boardComp);
+            if (entries == null || index < 0 || index >= entries.Count) return;
+
+            object entry = entries[index];
+            _suppressAcceptEntry = true;
+            try
+            {
+                acceptEntryMethod?.Invoke(null, [entry]);
+            }
+            finally
+            {
+                _suppressAcceptEntry = false;
+            }
+        }
+    }
+}

--- a/Source/Mods/IsekaiRPG.cs
+++ b/Source/Mods/IsekaiRPG.cs
@@ -31,6 +31,13 @@ namespace Multiplayer.Compat
         private static Type windowCreatureStatsType;
         private static Type iTabCreatureStatsType;
         private static Type mobRankComponentType;
+        private static Type auraFeelType;
+        private static Type isekaiGizmoProviderType;
+        private static Type forgeUtilityType;
+        private static Type refineResultType;
+        private static Type windowForgeType;
+        private static Type windowRunicStationType;
+        private static Type compForgeEnhancementType;
 
         private static FieldInfo[] statAllocationFields;
         private static FieldInfo statAllocationAvailablePoints;
@@ -65,6 +72,13 @@ namespace Multiplayer.Compat
             pawnStatGeneratorType = Resolve("IsekaiLeveling.PawnStatGenerator");
             treeAutoAssignerType = Resolve("IsekaiLeveling.SkillTree.TreeAutoAssigner");
             manaCoreCompType = Resolve("IsekaiLeveling.CompUseEffect_ManaCore");
+            auraFeelType = AccessTools.TypeByName("IsekaiLeveling.Abilities.AuraFeel");
+            isekaiGizmoProviderType = AccessTools.TypeByName("IsekaiLeveling.UI.IsekaiGizmoProvider");
+            forgeUtilityType = AccessTools.TypeByName("IsekaiLeveling.Forge.ForgeUtility");
+            refineResultType = AccessTools.TypeByName("IsekaiLeveling.Forge.ForgeUtility+RefineResult");
+            windowForgeType = AccessTools.TypeByName("IsekaiLeveling.Forge.Window_Forge");
+            windowRunicStationType = AccessTools.TypeByName("IsekaiLeveling.Forge.Window_RunicStation");
+            compForgeEnhancementType = AccessTools.TypeByName("IsekaiLeveling.Forge.CompForgeEnhancement");
 
             if (isekaiComponentType == null || isekaiStatAllocationType == null
                 || passiveTreeTrackerType == null || windowStatsType == null
@@ -91,7 +105,6 @@ namespace Multiplayer.Compat
             }
             else
             {
-
                 isekaiCompStatsField = AccessTools.Field(isekaiComponentType, "stats");
                 isekaiCompPassiveTreeField = AccessTools.Field(isekaiComponentType, "passiveTree");
 
@@ -115,12 +128,39 @@ namespace Multiplayer.Compat
                 PatchAndLog(iTabType, "FillTab", prefix: nameof(ITabFillTabPrefix), postfix: nameof(ITabFillTabPostfix));
                 PatchAndLog(windowStatsType, "ApplyChanges", prefix: nameof(ApplyChangesPrefix));
                 PatchAndLog(passiveTreeTrackerType, "Unlock", prefix: nameof(UnlockNodePrefix));
+                PatchAndLog(passiveTreeTrackerType, "TryUnlockChain", prefix: nameof(TryUnlockChainPrefix));
                 PatchAndLog(passiveTreeTrackerType, "Respec", prefix: nameof(RespecPrefix));
+
+                LongEventHandler.ExecuteWhenFinished(() =>
+                {
+                    if (isekaiGizmoProviderType != null && auraFeelType != null)
+                    {
+                        PatchAndLog(isekaiGizmoProviderType, "GetGizmos", postfix: nameof(GetGizmosPostfix));
+                        MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedActivateAuraPressure));
+                    }
+                });
+
+                if (forgeUtilityType != null)
+                {
+                    PatchAndLog(forgeUtilityType, "AttemptRefinement", prefix: nameof(AttemptRefinementPrefix));
+                    PatchAndLog(forgeUtilityType, "RepairItem", prefix: nameof(RepairItemPrefix));
+                    MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedAttemptRefinement));
+                    MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedRepairItem));
+                }
+
+                if (compForgeEnhancementType != null)
+                {
+                    PatchAndLog(compForgeEnhancementType, "TryAddRune", prefix: nameof(TryAddRunePrefix));
+                    PatchAndLog(compForgeEnhancementType, "RemoveRuneAt", prefix: nameof(RemoveRuneAtPrefix));
+                    MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedApplyRune));
+                    MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedRemoveRune));
+                }
 
                 MP.RegisterSyncWorker<object>(SyncIsekaiStatAllocation, isekaiStatAllocationType);
                 MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedDevAddLevel));
                 MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedApplyStats));
                 MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedUnlockNode));
+                MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedUnlockChain));
                 MP.RegisterSyncMethod(typeof(IsekaiRPGCompat), nameof(SyncedRespec));
                 MP.RegisterSyncDelegateLambda(manaCoreCompType, "GetBulkAbsorbOptions", 0);
             }
@@ -178,7 +218,17 @@ namespace Multiplayer.Compat
 
         private static ThingComp GetCompByType(Pawn pawn, Type compType)
         {
+            if (pawn?.AllComps == null || compType == null) return null;
             foreach (var comp in pawn.AllComps)
+                if (compType.IsInstanceOfType(comp))
+                    return comp;
+            return null;
+        }
+
+        private static ThingComp GetThingCompByType(Thing thing, Type compType)
+        {
+            if (thing is not ThingWithComps twc || twc.AllComps == null || compType == null) return null;
+            foreach (var comp in twc.AllComps)
                 if (compType.IsInstanceOfType(comp))
                     return comp;
             return null;
@@ -253,6 +303,8 @@ namespace Multiplayer.Compat
                 statAllocationAvailablePoints.SetValue(statsObj, remaining - pointsSpent);
             }
 
+            AccessTools.DeclaredMethod(pawnStatGeneratorType, "UpdateRankTraitFromStats")?.Invoke(null, [pawn, comp]);
+
             RefreshStatsWindows(pawn, statsObj);
         }
 
@@ -318,8 +370,42 @@ namespace Multiplayer.Compat
             if (passiveTree == null) { Log.Warning($"[IsekaiMP] SyncedUnlockNode: null passiveTree on {pawn.LabelShort}"); return; }
 
             _suppressUnlockPrefix = true;
-            try { AccessTools.DeclaredMethod(passiveTreeTrackerType, "Unlock").Invoke(passiveTree, [nodeId, pawn]); }
+            try { AccessTools.DeclaredMethod(passiveTreeTrackerType, "Unlock").Invoke(passiveTree, [nodeId, pawn, false]); }
             finally { _suppressUnlockPrefix = false; }
+        }
+
+        private static bool _suppressUnlockChainPrefix = false;
+
+        private static bool TryUnlockChainPrefix(string targetNodeId, Pawn pawn, ref int __result, ref int pointsSpent, ref string failReason)
+        {
+            if (!MP.IsInMultiplayer || _suppressUnlockChainPrefix || pawn == null) return true;
+            SyncedUnlockChain(pawn, targetNodeId);
+            __result = 0;
+            pointsSpent = 0;
+            failReason = null;
+            return false;
+        }
+
+        private static void SyncedUnlockChain(Pawn pawn, string targetNodeId)
+        {
+            var comp = GetCompByType(pawn, isekaiComponentType);
+            if (comp == null) return;
+
+            var passiveTree = isekaiCompPassiveTreeField.GetValue(comp);
+            if (passiveTree == null) return;
+
+            _suppressUnlockPrefix = true;
+            _suppressUnlockChainPrefix = true;
+            try
+            {
+                object[] args = [targetNodeId, pawn, 0, null];
+                AccessTools.DeclaredMethod(passiveTreeTrackerType, "TryUnlockChain")?.Invoke(passiveTree, args);
+            }
+            finally
+            {
+                _suppressUnlockPrefix = false;
+                _suppressUnlockChainPrefix = false;
+            }
         }
 
         private static bool _suppressRespecPrefix = false;
@@ -486,6 +572,212 @@ namespace Multiplayer.Compat
             MP.WatchBegin();
             foreach (var field in statSyncFields)
                 field.Watch(stats);
+        }
+
+        #endregion
+
+        #region Abilities
+
+        private static IEnumerable<Gizmo> GetGizmosPostfix(IEnumerable<Gizmo> __result, Pawn pawn)
+        {
+            foreach (var gizmo in __result)
+            {
+                if (gizmo is Command_Action cmd && cmd.defaultLabel == "Isekai_AuraFeel_Label".Translate())
+                {
+                    cmd.action = () => SyncedActivateAuraPressure(pawn);
+                }
+                yield return gizmo;
+            }
+        }
+
+        private static void SyncedActivateAuraPressure(Pawn pawn)
+        {
+            if (pawn == null) return;
+            var comp = GetCompByType(pawn, isekaiComponentType);
+            if (comp == null) return;
+
+            AccessTools.DeclaredMethod(auraFeelType, "Activate")?.Invoke(null, [pawn, comp]);
+        }
+
+        #endregion
+
+        #region Forge
+
+        private static bool _suppressRefinePrefix = false;
+
+        private static bool AttemptRefinementPrefix(Thing item, Map map, Pawn crafter, ref object __result)
+        {
+            if (!MP.IsInMultiplayer || _suppressRefinePrefix) return true;
+            SyncedAttemptRefinement(item, map);
+            if (refineResultType != null)
+                __result = Enum.ToObject(refineResultType, 1);
+            return false;
+        }
+
+        private static void SyncedAttemptRefinement(Thing item, Map map)
+        {
+            if (item == null || map == null) return;
+            _suppressRefinePrefix = true;
+            try
+            {
+                AccessTools.DeclaredMethod(forgeUtilityType, "AttemptRefinement")?.Invoke(null, [item, map, null]);
+            }
+            finally
+            {
+                _suppressRefinePrefix = false;
+            }
+        }
+
+        private static bool _suppressRepairPrefix = false;
+
+        private static bool RepairItemPrefix(Thing item, Map map, ref bool __result)
+        {
+            if (!MP.IsInMultiplayer || _suppressRepairPrefix) return true;
+            SyncedRepairItem(item, map);
+            __result = false;
+            return false;
+        }
+
+        private static void SyncedRepairItem(Thing item, Map map)
+        {
+            if (item == null || map == null) return;
+            _suppressRepairPrefix = true;
+            try
+            {
+                AccessTools.DeclaredMethod(forgeUtilityType, "RepairItem")?.Invoke(null, [item, map]);
+            }
+            finally
+            {
+                _suppressRepairPrefix = false;
+            }
+        }
+
+        #endregion
+
+        #region Runic Station
+
+        private static bool _suppressTryAddRune = false;
+
+        private static bool TryAddRunePrefix(ThingComp __instance, Def rune, int rank, ref bool __result)
+        {
+            if (!MP.IsInMultiplayer || _suppressTryAddRune) return true;
+            if (windowRunicStationType == null || Find.WindowStack?.IsOpen(windowRunicStationType) == true)
+            {
+                if (rune != null && __instance?.parent != null)
+                {
+                    SyncedApplyRune(__instance.parent, rune.defName, rank);
+                    __result = false;
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static void SyncedApplyRune(Thing equipment, string runeDefName, int rank)
+        {
+            if (equipment == null || string.IsNullOrEmpty(runeDefName)) return;
+            var comp = GetThingCompByType(equipment, compForgeEnhancementType);
+            if (comp == null) return;
+
+            var runeDefType = AccessTools.TypeByName("IsekaiLeveling.Forge.RuneDef");
+            if (runeDefType == null) return;
+
+            var runeDef = GenDefDatabase.GetDef(runeDefType, runeDefName, false);
+            if (runeDef == null) return;
+
+            _suppressTryAddRune = true;
+            try
+            {
+                var tryAddRuneMethod = AccessTools.DeclaredMethod(compForgeEnhancementType, "TryAddRune");
+                if (tryAddRuneMethod == null) return;
+
+                bool added = (bool)tryAddRuneMethod.Invoke(comp, [runeDef, rank]);
+                if (added && !(Prefs.DevMode && DebugSettings.godMode))
+                {
+                    string runeBaseName = runeDefName.StartsWith("Isekai_RuneDef_")
+                        ? runeDefName.Substring("Isekai_RuneDef_".Length)
+                        : runeDefName;
+                    string itemDefName;
+                    switch (rank)
+                    {
+                        case 5: itemDefName = $"Isekai_Rune_{runeBaseName}_V"; break;
+                        case 4: itemDefName = $"Isekai_Rune_{runeBaseName}_IV"; break;
+                        case 3: itemDefName = $"Isekai_Rune_{runeBaseName}_III"; break;
+                        case 2: itemDefName = $"Isekai_Rune_{runeBaseName}_II"; break;
+                        default: itemDefName = $"Isekai_Rune_{runeBaseName}"; break;
+                    }
+
+                    Map map = equipment.MapHeld ?? Find.CurrentMap;
+                    Thing runeItem = null;
+                    if (map?.listerThings?.AllThings != null)
+                    {
+                        foreach (var t in map.listerThings.AllThings)
+                        {
+                            if (t != null && !t.Destroyed && t.def?.defName == itemDefName && t.stackCount >= 1)
+                            {
+                                runeItem = t;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (runeItem == null && Find.Maps != null)
+                    {
+                        foreach (var m in Find.Maps)
+                        {
+                            if (m == map || m.listerThings?.AllThings == null) continue;
+                            foreach (var t in m.listerThings.AllThings)
+                            {
+                                if (t != null && !t.Destroyed && t.def?.defName == itemDefName && t.stackCount >= 1)
+                                {
+                                    runeItem = t;
+                                    break;
+                                }
+                            }
+                            if (runeItem != null) break;
+                        }
+                    }
+
+                    if (runeItem != null)
+                    {
+                        if (runeItem.stackCount > 1)
+                            runeItem.stackCount -= 1;
+                        else
+                            runeItem.Destroy();
+                    }
+                }
+            }
+            finally
+            {
+                _suppressTryAddRune = false;
+            }
+        }
+
+        private static bool _suppressRemoveRune = false;
+
+        private static bool RemoveRuneAtPrefix(ThingComp __instance, int index, ref bool __result)
+        {
+            if (!MP.IsInMultiplayer || _suppressRemoveRune) return true;
+            SyncedRemoveRune(__instance.parent, index);
+            __result = false;
+            return false;
+        }
+
+        private static void SyncedRemoveRune(Thing equipment, int index)
+        {
+            if (equipment == null) return;
+            var comp = GetThingCompByType(equipment, compForgeEnhancementType);
+            if (comp == null) return;
+
+            _suppressRemoveRune = true;
+            try
+            {
+                AccessTools.DeclaredMethod(compForgeEnhancementType, "RemoveRuneAt").Invoke(comp, [index]);
+            }
+            finally
+            {
+                _suppressRemoveRune = false;
+            }
         }
 
         #endregion


### PR DESCRIPTION

- Update Isekai RPG Leveling: sync skill tree chain unlocks, rank trait updates, Aura Pressure ability, forge refinement/repair, and runic station socketing/removal. Fix main-thread texture loading.

- Add Guild Faction Add-on: sync quest board entry acceptance and deterministic daily refresh.

- Add Isekai Creatures Add-on: sync pet drafting toggle, creature sealing designation, and creature taming designation.